### PR TITLE
Done basic tasks execution setup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,9 +13,11 @@ repositories {
 }
 
 dependencies {
+    implementation ("org.jfrog.buildinfo:build-info-extractor:2+")
+    implementation ("org.jfrog.buildinfo:build-info-api:2+")
+    implementation("org.jfrog.filespecs:file-specs-java:1+")
     testImplementation("org.testng:testng:7.7.1")
     "functionalTestImplementation"("org.testng:testng:7.7.1")
-//    "functionalTestImplementation"(project)
 }
 
 gradlePlugin {

--- a/src/main/java/org/jfrog/buildinfo/ArtifactoryPlugin.java
+++ b/src/main/java/org/jfrog/buildinfo/ArtifactoryPlugin.java
@@ -2,47 +2,66 @@ package org.jfrog.buildinfo;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.jfrog.buildinfo.config.ArtifactoryPluginConvention;
+import org.jfrog.buildinfo.extractor.listener.ArtifactoryDependencyResolutionListener;
+import org.jfrog.buildinfo.extractor.listener.ProjectsEvaluatedBuildListener;
+import org.jfrog.buildinfo.tasks.CollectDeployDetailsTask;
+import org.jfrog.buildinfo.tasks.ExtractBuildInfoTask;
 import org.jfrog.buildinfo.tasks.HelloWorldTask;
+import org.jfrog.buildinfo.utils.Constant;
+import org.jfrog.buildinfo.utils.ConventionUtils;
+import org.jfrog.buildinfo.utils.ProjectUtils;
+import org.jfrog.buildinfo.utils.TaskUtils;
 
 public class ArtifactoryPlugin implements Plugin<Project> {
+    private static final Logger log = Logging.getLogger(ArtifactoryPlugin.class);
+    private final ArtifactoryDependencyResolutionListener resolutionListener = new ArtifactoryDependencyResolutionListener();
 
     @Override
     public void apply(Project project) {
         if (isGradleVersionNotSupported(project)) {
-            System.out.println("Can't apply on Gradle version " + project.getGradle().getGradleVersion());
+            log.error("Can't apply Artifactory Plugin on Gradle version " + project.getGradle().getGradleVersion());
             return;
         }
+        // Add an Artifactory plugin convention to the project module
+        ArtifactoryPluginConvention convention = ConventionUtils.getOrCreateArtifactoryConvention(project);
+        // Then add the collect deploy details task to collect publishing information on the module
+        CollectDeployDetailsTask collectDeployDetailsTask = TaskUtils.addCollectDeployDetailsTask(project);
+        TaskUtils.addExtractModuleInfoTask(collectDeployDetailsTask);
 
-        for (Project proj : project.getAllprojects()) {
-            addPluginTasks(proj);
+        if (ProjectUtils.isRootProject(project)) {
+            // Build-info, Deploy and Distribute tasks are added once for the root to finalize all modules tasks that prepare the needed information
+            ExtractBuildInfoTask extractBuildInfoTask = TaskUtils.addExtractBuildInfoTask(project);
+            TaskUtils.addDeploymentTask(extractBuildInfoTask);
+            // Add a DependencyResolutionListener, to populate the dependency hierarchy map.
+            project.getGradle().addListener(resolutionListener);
+        } else {
+            // Makes sure the plugin is applied in the root project
+            project.getRootProject().getPluginManager().apply(ArtifactoryPlugin.class);
         }
-    }
 
-    private void addPluginTasks(Project project) {
+        // TODO: Remove
         project.getTasks().maybeCreate(HelloWorldTask.TASK_NAME, HelloWorldTask.class);
+
+
+        // Set build started if not set
+        // TODO: check why
+        String buildStarted = convention.getClientConfig().info.getBuildStarted();
+        if (buildStarted == null || buildStarted.isEmpty()) {
+            convention.getClientConfig().info.setBuildStarted(System.currentTimeMillis());
+        }
+
+        project.getGradle().addProjectEvaluationListener(new ProjectsEvaluatedBuildListener());
+        log.debug("Using Artifactory Plugin for " + project.getPath());
     }
 
     public boolean isGradleVersionNotSupported(Project project) {
-        return compareVersions(Constant.MIN_GRADLE_VERSION, project.getGradle().getGradleVersion()) > 0;
+        return Constant.MIN_GRADLE_VERSION.compareTo(project.getGradle().getGradleVersion()) > 0;
     }
 
-    private  int compareVersions(String version1, String version2) {
-        String[] segments1 = version1.split("\\.");
-        String[] segments2 = version2.split("\\.");
-
-        int length = Math.max(segments1.length, segments2.length);
-
-        for (int i = 0; i < length; i++) {
-            int segment1 = i < segments1.length ? Integer.parseInt(segments1[i]) : 0;
-            int segment2 = i < segments2.length ? Integer.parseInt(segments2[i]) : 0;
-
-            if (segment1 < segment2) {
-                return -1;
-            } else if (segment1 > segment2) {
-                return 1;
-            }
-        }
-
-        return 0; // Versions are equal
+    public ArtifactoryDependencyResolutionListener getResolutionListener() {
+        return resolutionListener;
     }
 }

--- a/src/main/java/org/jfrog/buildinfo/config/ArtifactoryPluginConvention.java
+++ b/src/main/java/org/jfrog/buildinfo/config/ArtifactoryPluginConvention.java
@@ -1,0 +1,26 @@
+package org.jfrog.buildinfo.config;
+
+import org.gradle.api.Project;
+import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
+import org.jfrog.buildinfo.utils.GradleClientLogger;
+
+public class ArtifactoryPluginConvention {
+
+    private final Project project;
+
+    private final ArtifactoryClientConfiguration clientConfig;
+
+    public ArtifactoryPluginConvention(Project project) {
+        this.project = project;
+        clientConfig = new ArtifactoryClientConfiguration(new GradleClientLogger(project.getLogger()));
+    }
+
+
+    public Project getProject() {
+        return project;
+    }
+
+    public ArtifactoryClientConfiguration getClientConfig() {
+        return clientConfig;
+    }
+}

--- a/src/main/java/org/jfrog/buildinfo/extractor/ModuleInfoFileProducer.java
+++ b/src/main/java/org/jfrog/buildinfo/extractor/ModuleInfoFileProducer.java
@@ -1,0 +1,21 @@
+package org.jfrog.buildinfo.extractor;
+
+import org.gradle.api.file.FileCollection;
+
+/**
+ * Represents a producer of module-info files
+ */
+public interface ModuleInfoFileProducer {
+
+    /**
+     * Check whether the module info file will actually contain modules or not.
+     * @return true if the module info file will contain modules
+     */
+    boolean hasModules();
+
+    /**
+     * Get the module info file.
+     * @return the module info file
+     */
+    FileCollection getModuleInfoFiles();
+}

--- a/src/main/java/org/jfrog/buildinfo/extractor/listener/ArtifactoryDependencyResolutionListener.java
+++ b/src/main/java/org/jfrog/buildinfo/extractor/listener/ArtifactoryDependencyResolutionListener.java
@@ -1,0 +1,121 @@
+package org.jfrog.buildinfo.extractor.listener;
+
+import org.gradle.api.artifacts.DependencyResolutionListener;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ResolvableDependencies;
+import org.gradle.api.artifacts.result.DependencyResult;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.artifacts.result.ResolvedDependencyResult;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.jfrog.buildinfo.utils.ProjectUtils;
+
+import java.util.*;
+
+/**
+ * Represents a DependencyResolutionListener, used to populate a dependency hierarchy map for each dependency in each module,
+ * which is used in the 'requestedBy' field of every dependency in the build info, by listening to the 'afterResolve' event of every module.
+ */
+public class ArtifactoryDependencyResolutionListener implements DependencyResolutionListener {
+    private static final Logger log = Logging.getLogger(ArtifactoryDependencyResolutionListener.class);
+    private final Map<String, Map<String, String[][]>> modulesHierarchyMap = new HashMap<>();
+
+    @Override
+    public void beforeResolve(ResolvableDependencies dependencies) {}
+
+    @Override
+    public void afterResolve(ResolvableDependencies dependencies) {
+        if (!dependencies.getResolutionResult().getAllDependencies().isEmpty()) {
+            updateModulesMap(dependencies);
+        }
+        log.info("<ASSAF> Done update after dependency resolved");
+    }
+
+    /**
+     * Get the Group, artifact and version of the given module
+     * @param module - the module to extract the GAV info
+     * @return Gav identifier string of the module or null if module is null
+     */
+    private static String getGav(ModuleVersionIdentifier module) {
+        if (module == null) {
+            return null;
+        }
+        return ProjectUtils.getAsGavString(module.getGroup(), module.getName(), module.getVersion());
+    }
+
+    /**
+     * Update the modules map with the resolved dependencies.
+     * @param dependencies - resolved dependencies to update the map
+     */
+    private void updateModulesMap(ResolvableDependencies dependencies) {
+        String moduleId = getGav(dependencies.getResolutionResult().getRoot().getModuleVersion());
+        if (moduleId == null) {
+            return;
+        }
+        log.info("<ASSAF> updating module: " + moduleId);
+        Map<String, String[][]> dependenciesMap = modulesHierarchyMap.computeIfAbsent(moduleId, k -> new HashMap<>());
+        updateDependencyMap(dependenciesMap, dependencies.getResolutionResult().getAllDependencies());
+    }
+
+    /**
+     * Update the resolved dependency map with the given information.
+     * @param dependencyMap - the map that holds the modules resolved dependencies information
+     * @param dependencies - the resolved dependencies to update the map
+     */
+    private void updateDependencyMap(Map<String, String[][]> dependencyMap, Set<? extends DependencyResult> dependencies) {
+        for (DependencyResult dependency : dependencies) {
+            if (!(dependency instanceof ResolvedDependencyResult)) {
+                continue;
+            }
+            ResolvedDependencyResult resolvedDependency = (ResolvedDependencyResult) dependency;
+            String componentId = getGav(resolvedDependency.getSelected().getModuleVersion());
+            log.info("<ASSAF> dependency: " + componentId + " | already collected: " + (dependencyMap.get(componentId) != null));
+            if (dependencyMap.containsKey(componentId)) {
+                // Only add information that was not collected yet for the given module.
+                continue;
+            }
+            dependencyMap.put(componentId, getDependencyDependents(resolvedDependency));
+        }
+    }
+
+    /**
+     * Get pathToRoot list of transitive dependencies. Root is expected to be last in list.
+     * @param resolvedDependency - the dependency to resolve from.
+     * @return Dependents list of a given dependency
+     */
+    private String[][] getDependencyDependents(ResolvedDependencyResult resolvedDependency) {
+        List<String> dependents = new ArrayList<>();
+        populateDependents(resolvedDependency, dependents);
+        log.info("<ASSAF> Dependents from resolved:\n" + dependents);
+        return new String[][] { dependents.toArray(new String[0])};
+    }
+
+    /**
+     * Recursively populate a pathToRoot list of transitive dependencies. Root is expected to be last in list.
+     * @param dependency - To populate the dependents list for.
+     * @param dependents - Dependents list to populate.
+     */
+    private void populateDependents(ResolvedDependencyResult dependency, List<String> dependents) {
+        ResolvedComponentResult from = dependency.getFrom();
+        if (from.getDependents().isEmpty()) {
+            if (from.getSelectionReason().isExpected()) {
+                // If the dependency was requested by root, append the root's GAV.
+                dependents.add(getGav(from.getModuleVersion()));
+                return;
+            }
+            // Unexpected result.
+            throw new RuntimeException("Failed populating dependency parents map: dependency has no dependents and is not root.");
+        }
+        // We assume the first parent in the list, is the item that triggered this dependency resolution.
+        ResolvedDependencyResult parent = from.getDependents().iterator().next();
+        String parentGav = getGav(parent.getSelected().getModuleVersion());
+        // Check for circular dependencies loop. We do this check to avoid an infinite loop dependencies. For example: A --> B --> C --> A...
+        if (dependents.contains(parentGav)) {
+            return;
+        }
+        // Append the current parent's GAV to list.
+        dependents.add(parentGav);
+        // Continue populating dependents list.
+        populateDependents(parent, dependents);
+    }
+}

--- a/src/main/java/org/jfrog/buildinfo/extractor/listener/ProjectsEvaluatedBuildListener.java
+++ b/src/main/java/org/jfrog/buildinfo/extractor/listener/ProjectsEvaluatedBuildListener.java
@@ -1,0 +1,92 @@
+package org.jfrog.buildinfo.extractor.listener;
+
+import org.gradle.BuildAdapter;
+import org.gradle.StartParameter;
+import org.gradle.api.Project;
+import org.gradle.api.ProjectEvaluationListener;
+import org.gradle.api.ProjectState;
+import org.gradle.api.Task;
+import org.gradle.api.invocation.Gradle;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
+import org.jfrog.buildinfo.config.ArtifactoryPluginConvention;
+import org.jfrog.buildinfo.tasks.CollectDeployDetailsTask;
+import org.jfrog.buildinfo.utils.Constant;
+import org.jfrog.buildinfo.utils.ConventionUtils;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+
+/**
+ * Build event listener to prepare data for publish Task after the projects are evaluated
+ * Main actions:
+ * 1) Setting the deployment task as a final task for all the CollectDeployDetailsTask tasks
+ */
+public class ProjectsEvaluatedBuildListener extends BuildAdapter implements ProjectEvaluationListener {
+    private static final Logger log = Logging.getLogger(ProjectsEvaluatedBuildListener.class);
+    private final Set<Task> detailsCollectingTasks = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    /**
+     * Evaluate the given collectDeployDetailsTask task, preform the follows:
+     * 1) Fill the client configuration of the task's project with user and system properties.
+     * 2) Adds publishers to the task to collect build details from.
+     * @param collectDeployDetailsTask
+     */
+    private void evaluate(CollectDeployDetailsTask collectDeployDetailsTask) {
+        log.debug("Evaluating CollectDeployDetailsTask {}", collectDeployDetailsTask);
+        ArtifactoryPluginConvention convention = ConventionUtils.getArtifactoryConvention(collectDeployDetailsTask.getProject());
+        if (convention == null) {
+            return;
+        }
+
+        ArtifactoryClientConfiguration clientConfiguration = convention.getClientConfig();
+
+    }
+
+    /**
+     * This method is invoked after evaluation of every project.
+     * If the configure-on-demand mode is active, Evaluates the CollectDeployDetailsTask tasks
+     * @param project The project which was evaluated. Never null.
+     * @param state The project evaluation state. If project evaluation failed, the exception is available in this
+     * state. Never null.
+     */
+    @Override
+    public void afterEvaluate(Project project, ProjectState state) {
+        Set<Task> tasks = project.getTasksByName(Constant.ARTIFACTORY_PUBLISH_TASK_NAME, false);
+        StartParameter startParameter = project.getGradle().getStartParameter();
+        tasks.forEach(task -> {
+            if (task instanceof CollectDeployDetailsTask) {
+                CollectDeployDetailsTask collectDeployDetailsTask = (CollectDeployDetailsTask) task;
+                detailsCollectingTasks.add(collectDeployDetailsTask);
+                collectDeployDetailsTask.finalizeByExtractTask();
+                if (startParameter.isConfigureOnDemand()) {
+                    evaluate(collectDeployDetailsTask);
+                }
+            }
+        });
+    }
+
+    /**
+     * this method is invoked after all projects are evaluated.
+     * Evaluate all the CollectDeployDetailsTask tasks that are not yet evaluated.
+     * @param gradle The build which has been evaluated. Never null.
+     */
+    @Override
+    public void projectsEvaluated(Gradle gradle) {
+        Set<Task> tasks = gradle.getRootProject().getTasksByName(Constant.ARTIFACTORY_PUBLISH_TASK_NAME, false);
+        detailsCollectingTasks.addAll(tasks);
+        detailsCollectingTasks.forEach(task -> {
+            if ((task instanceof CollectDeployDetailsTask) && !((CollectDeployDetailsTask) task).isEvaluated()) {
+                CollectDeployDetailsTask collectDeployDetailsTask = (CollectDeployDetailsTask) task;
+                evaluate(collectDeployDetailsTask);
+                collectDeployDetailsTask.finalizeByExtractTask();
+            }
+        });
+    }
+
+    @Override
+    public void beforeEvaluate(Project project) {}
+}

--- a/src/main/java/org/jfrog/buildinfo/tasks/CollectDeployDetailsTask.java
+++ b/src/main/java/org/jfrog/buildinfo/tasks/CollectDeployDetailsTask.java
@@ -9,9 +9,7 @@ import org.gradle.api.publish.ivy.IvyPublication;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
-import org.jfrog.buildinfo.config.ArtifactoryPluginConvention;
 import org.jfrog.buildinfo.utils.Constant;
-import org.jfrog.buildinfo.utils.ConventionUtils;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -32,24 +30,12 @@ public class CollectDeployDetailsTask extends DefaultTask {
         log.debug("<ASSAF> Task '{}' activated", getPath());
     }
 
-    /**
-     * Set the project root ExtractBuildInfoTask task to run after this task is done
-     */
-    public void finalizeByExtractTask() {
-        Task deployTask = getProject().getRootProject().getTasks().findByName(Constant.EXTRACT_BUILD_INFO_TASK_NAME);
-        if (deployTask == null) {
-            throw new IllegalStateException(String.format("Could not find %s in the root project", Constant.EXTRACT_BUILD_INFO_TASK_NAME));
-        }
-        finalizedBy(deployTask);
-    }
-
     public void taskEvaluated() {
         Project project = getProject();
 
-        ArtifactoryPluginConvention convention = ConventionUtils.getPublisherConvention(project);
-
+        // Depends on Information Collection from all the subprojects
         for (Project sub : project.getSubprojects()) {
-            Task subCollectInfoTask = sub.getTasks().findByName(Constant.ARTIFACTORY_PUBLISH_TASK_NAME);
+            Task subCollectInfoTask = sub.getTasks().findByName(Constant.COLLECT_PUBLISH_INFO_TASK_NAME);
             if (subCollectInfoTask != null) {
                 dependsOn(subCollectInfoTask);
             }

--- a/src/main/java/org/jfrog/buildinfo/tasks/CollectDeployDetailsTask.java
+++ b/src/main/java/org/jfrog/buildinfo/tasks/CollectDeployDetailsTask.java
@@ -1,0 +1,70 @@
+package org.jfrog.buildinfo.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.publish.ivy.IvyPublication;
+import org.gradle.api.publish.maven.MavenPublication;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.TaskAction;
+import org.jfrog.buildinfo.config.ArtifactoryPluginConvention;
+import org.jfrog.buildinfo.utils.Constant;
+import org.jfrog.buildinfo.utils.ConventionUtils;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+public class CollectDeployDetailsTask extends DefaultTask {
+    private static final Logger log = Logging.getLogger(CollectDeployDetailsTask.class);
+
+    public Set<IvyPublication> ivyPublications = new HashSet<>();
+
+    public Set<MavenPublication> mavenPublications = new HashSet<>();
+
+    private boolean ciServerBuild = false;
+    private boolean evaluated = false;
+
+    @TaskAction
+    public void taskAction() throws IOException {
+        log.debug("<ASSAF> Task '{}' activated", getPath());
+    }
+
+    /**
+     * Set the project root ExtractBuildInfoTask task to run after this task is done
+     */
+    public void finalizeByExtractTask() {
+        Task deployTask = getProject().getRootProject().getTasks().findByName(Constant.EXTRACT_BUILD_INFO_TASK_NAME);
+        if (deployTask == null) {
+            throw new IllegalStateException(String.format("Could not find %s in the root project", Constant.EXTRACT_BUILD_INFO_TASK_NAME));
+        }
+        finalizedBy(deployTask);
+    }
+
+    public void taskEvaluated() {
+        Project project = getProject();
+
+        ArtifactoryPluginConvention convention = ConventionUtils.getPublisherConvention(project);
+
+        for (Project sub : project.getSubprojects()) {
+            Task subCollectInfoTask = sub.getTasks().findByName(Constant.ARTIFACTORY_PUBLISH_TASK_NAME);
+            if (subCollectInfoTask != null) {
+                dependsOn(subCollectInfoTask);
+            }
+        }
+
+        evaluated = true;
+    }
+
+    @Internal
+    public boolean isEvaluated() {
+        return evaluated;
+    }
+
+
+    public boolean hasModules() {
+        return false;
+    }
+}

--- a/src/main/java/org/jfrog/buildinfo/tasks/DeployTask.java
+++ b/src/main/java/org/jfrog/buildinfo/tasks/DeployTask.java
@@ -1,0 +1,19 @@
+package org.jfrog.buildinfo.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.IOException;
+
+public class DeployTask extends DefaultTask {
+
+    private static final Logger log = Logging.getLogger(DeployTask.class);
+
+    @TaskAction
+    public void taskAction() throws IOException {
+        log.debug("<ASSAF> Task '{}' activated", getPath());
+    }
+
+}

--- a/src/main/java/org/jfrog/buildinfo/tasks/ExtractBuildInfoTask.java
+++ b/src/main/java/org/jfrog/buildinfo/tasks/ExtractBuildInfoTask.java
@@ -1,0 +1,23 @@
+package org.jfrog.buildinfo.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.TaskAction;
+import org.jfrog.buildinfo.extractor.ModuleInfoFileProducer;
+
+import java.io.IOException;
+
+public class ExtractBuildInfoTask extends DefaultTask {
+
+    private static final Logger log = Logging.getLogger(ExtractBuildInfoTask.class);
+
+    @TaskAction
+    public void taskAction() throws IOException {
+        log.debug("<ASSAF> Task '{}' activated", getPath());
+    }
+
+    public void registerModuleInfoProducer(ModuleInfoFileProducer moduleInfoFileProducer) {
+
+    }
+}

--- a/src/main/java/org/jfrog/buildinfo/tasks/ExtractModuleTask.java
+++ b/src/main/java/org/jfrog/buildinfo/tasks/ExtractModuleTask.java
@@ -1,0 +1,25 @@
+package org.jfrog.buildinfo.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+public class ExtractModuleTask extends DefaultTask {
+
+    private static final Logger log = Logging.getLogger(ExtractModuleTask.class);
+    private final RegularFileProperty moduleFile = getProject().getObjects().fileProperty();
+
+    @OutputFile
+    public RegularFileProperty getModuleFile() {
+        return moduleFile;
+    }
+
+    @TaskAction
+    public void extractModule() {
+        log.debug("<ASSAF> Task '{}' activated", getPath());
+    }
+
+}

--- a/src/main/java/org/jfrog/buildinfo/utils/Constant.java
+++ b/src/main/java/org/jfrog/buildinfo/utils/Constant.java
@@ -8,10 +8,10 @@ public class Constant {
     public static final String MIN_GRADLE_VERSION = "6.9";
 
     // Plugin tasks names
-    public static final String ARTIFACTORY_PUBLISH_TASK_NAME = "artifactoryPublish";
+    public static final String COLLECT_PUBLISH_INFO_TASK_NAME = "collectPublishInfo";
     public static final String EXTRACT_MODULE_TASK_NAME = "extractModuleInfo";
     public static final String EXTRACT_BUILD_INFO_TASK_NAME = "extractBuildInfo";
-    public static final String DEPLOY_TASK_NAME = "artifactoryDeploy";
+    public static final String DEPLOY_TASK_NAME = "artifactoryPublish";
 
     // Plugin generated file names (intermediate)
     public static final String MODULE_INFO_FILE_NAME = "moduleInfo.json";

--- a/src/main/java/org/jfrog/buildinfo/utils/Constant.java
+++ b/src/main/java/org/jfrog/buildinfo/utils/Constant.java
@@ -1,0 +1,19 @@
+package org.jfrog.buildinfo.utils;
+
+public class Constant {
+    public static final String ARTIFACTORY = "artifactory";
+    public static final String PUBLISH_TASK_GROUP = "publishing";
+
+    // Minimum Gradle version to use the plugin
+    public static final String MIN_GRADLE_VERSION = "6.9";
+
+    // Plugin tasks names
+    public static final String ARTIFACTORY_PUBLISH_TASK_NAME = "artifactoryPublish";
+    public static final String EXTRACT_MODULE_TASK_NAME = "extractModuleInfo";
+    public static final String EXTRACT_BUILD_INFO_TASK_NAME = "extractBuildInfo";
+    public static final String DEPLOY_TASK_NAME = "artifactoryDeploy";
+
+    // Plugin generated file names (intermediate)
+    public static final String MODULE_INFO_FILE_NAME = "moduleInfo.json";
+    public static final String BUILD_INFO_FILE_NAME = "build-info.json";
+}

--- a/src/main/java/org/jfrog/buildinfo/utils/ConventionUtils.java
+++ b/src/main/java/org/jfrog/buildinfo/utils/ConventionUtils.java
@@ -1,0 +1,40 @@
+package org.jfrog.buildinfo.utils;
+
+import org.gradle.api.Project;
+import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
+import org.jfrog.buildinfo.config.ArtifactoryPluginConvention;
+
+public class ConventionUtils {
+    public static ArtifactoryPluginConvention getOrCreateArtifactoryConvention(Project project) {
+        ArtifactoryPluginConvention con = project.getConvention().findPlugin(ArtifactoryPluginConvention.class);
+        if (con == null) {
+            con = project.getExtensions().create(Constant.ARTIFACTORY, ArtifactoryPluginConvention.class, project);
+        }
+        return con;
+    }
+
+    public static ArtifactoryPluginConvention getArtifactoryConvention(Project project) {
+        while (project != null) {
+            ArtifactoryPluginConvention con = project.getConvention().findPlugin(ArtifactoryPluginConvention.class);
+            if (con != null) {
+                return con;
+            }
+            project = project.getParent();
+        }
+        return null;
+    }
+
+    public static ArtifactoryPluginConvention getPublisherConvention(Project project) {
+        while (project != null) {
+            ArtifactoryPluginConvention acc = project.getConvention().findPlugin(ArtifactoryPluginConvention.class);
+            if (acc != null) {
+                ArtifactoryClientConfiguration.PublisherHandler publisher = acc.getClientConfig().publisher;
+                if (publisher.getContextUrl() != null && (publisher.getRepoKey() != null || publisher.getSnapshotRepoKey() != null)) {
+                    return acc;
+                }
+            }
+            project = project.getParent();
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/jfrog/buildinfo/utils/GradleClientLogger.java
+++ b/src/main/java/org/jfrog/buildinfo/utils/GradleClientLogger.java
@@ -1,0 +1,42 @@
+package org.jfrog.buildinfo.utils;
+
+import org.gradle.api.logging.LogLevel;
+import org.gradle.api.logging.Logger;
+import org.jfrog.build.api.util.Log;
+
+/**
+ * Logger that is to be used for the HTTP client when using Gradle.
+ */
+public class GradleClientLogger implements Log {
+
+    private Logger logger;
+
+    public GradleClientLogger(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void debug(String message) {
+        this.logger.log(LogLevel.DEBUG, message);
+    }
+
+    @Override
+    public void info(String message) {
+        this.logger.log(LogLevel.LIFECYCLE, message);
+    }
+
+    @Override
+    public void warn(String message) {
+        this.logger.log(LogLevel.WARN, message);
+    }
+
+    @Override
+    public void error(String message) {
+        this.logger.log(LogLevel.ERROR, message);
+    }
+
+    @Override
+    public void error(String message, Throwable e) {
+        this.logger.log(LogLevel.ERROR, message, e);
+    }
+}

--- a/src/main/java/org/jfrog/buildinfo/utils/ProjectUtils.java
+++ b/src/main/java/org/jfrog/buildinfo/utils/ProjectUtils.java
@@ -1,0 +1,30 @@
+package org.jfrog.buildinfo.utils;
+
+import org.gradle.api.Project;
+
+public class ProjectUtils {
+
+    public static boolean isRootProject(Project project) {
+        return project.equals(project.getRootProject());
+    }
+
+    /**
+     * Return true if at least one of the input components exists in the project.
+     * @param project - The Gradle project of the task
+     * @return true if at least one of the input components exists in the project.
+     */
+    public static boolean projectHasOneOfComponents(Project project, String... componentNames) {
+        for (String componentName : componentNames) {
+            if (project.getComponents().findByName(componentName) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static String getAsGavString(String group, String name, String version) {
+        return group + ':' + name + ':' + version;
+    }
+
+
+}

--- a/src/main/java/org/jfrog/buildinfo/utils/TaskUtils.java
+++ b/src/main/java/org/jfrog/buildinfo/utils/TaskUtils.java
@@ -1,0 +1,116 @@
+package org.jfrog.buildinfo.utils;
+
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.file.FileCollection;
+import org.jfrog.buildinfo.extractor.ModuleInfoFileProducer;
+import org.jfrog.buildinfo.tasks.CollectDeployDetailsTask;
+import org.jfrog.buildinfo.tasks.DeployTask;
+import org.jfrog.buildinfo.tasks.ExtractBuildInfoTask;
+import org.jfrog.buildinfo.tasks.ExtractModuleTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TaskUtils {
+    private static final Logger log = LoggerFactory.getLogger(TaskUtils.class);
+
+    /**
+     * Adds to a given project a task to collect all the publications and information to be deployed.
+     * @param project - the module to collect information from
+     * @return - task that was created for the given module
+     */
+    public static CollectDeployDetailsTask addCollectDeployDetailsTask(Project project) {
+        Task task = project.getTasks().findByName(Constant.ARTIFACTORY_PUBLISH_TASK_NAME);
+        if (task instanceof CollectDeployDetailsTask) {
+            return (CollectDeployDetailsTask) task;
+        }
+        log.debug("Configuring {} task for project (is root: {}) {}", Constant.ARTIFACTORY_PUBLISH_TASK_NAME, ProjectUtils.isRootProject(project), project.getPath());
+
+        CollectDeployDetailsTask collectDeployDetailsTask = project.getTasks().create(Constant.ARTIFACTORY_PUBLISH_TASK_NAME, CollectDeployDetailsTask.class);
+        collectDeployDetailsTask.setDescription("Collect artifacts to be later used to generate build-info and deploy.");
+        collectDeployDetailsTask.setGroup(Constant.PUBLISH_TASK_GROUP);
+
+        return collectDeployDetailsTask;
+    }
+
+    /**
+     * Adds a task that will run after the given collectDeployDetailsTask task and will extract module info file from the information collected.
+     * An ExtractModuleTask task will be added (if not exists) to the given task's project.
+     * @param collectDeployDetailsTask - the task that will provide the information to produce the module info file
+     */
+    public static void addExtractModuleInfoTask(CollectDeployDetailsTask collectDeployDetailsTask) {
+        Project project = collectDeployDetailsTask.getProject();
+        Task task = project.getTasks().findByName(Constant.EXTRACT_MODULE_TASK_NAME);
+        if (!(task instanceof ExtractModuleTask)) {
+            log.debug("Configuring {} task for project (is root: {}) {}", Constant.EXTRACT_MODULE_TASK_NAME, ProjectUtils.isRootProject(project), project.getPath());
+            task = project.getTasks().create(Constant.EXTRACT_MODULE_TASK_NAME, ExtractModuleTask.class);
+            task.setDescription("Extracts module info to an intermediate file.");
+        }
+        ExtractModuleTask extractModuleTask = (ExtractModuleTask) task;
+
+        extractModuleTask.getOutputs().upToDateWhen(reuseOutputs -> false);
+        extractModuleTask.getModuleFile().set(project.getLayout().getBuildDirectory().file(Constant.MODULE_INFO_FILE_NAME));
+//        extractModuleTask.mustRunAfter(project.getTasks().withType(CollectDeployDetailsTask.class));
+        collectDeployDetailsTask.finalizedBy(extractModuleTask);
+
+        project.getRootProject().getTasks().withType(ExtractBuildInfoTask.class).configureEach(extractBuildInfoTask -> extractBuildInfoTask.registerModuleInfoProducer(new DefaultModuleInfoFileProducer(collectDeployDetailsTask, extractModuleTask)));
+    }
+
+    public static ExtractBuildInfoTask addExtractBuildInfoTask(Project project) {
+        Task task = project.getTasks().findByName(Constant.EXTRACT_BUILD_INFO_TASK_NAME);
+        if (task instanceof ExtractBuildInfoTask) {
+            return (ExtractBuildInfoTask) task;
+        }
+        log.debug("Configuring {} task for root project {}", Constant.EXTRACT_BUILD_INFO_TASK_NAME, project.getPath());
+
+        ExtractBuildInfoTask extractBuildInfoTask = project.getTasks().create(Constant.EXTRACT_BUILD_INFO_TASK_NAME, ExtractBuildInfoTask.class);
+        extractBuildInfoTask.setDescription("Extracts build info to a file.");
+        extractBuildInfoTask.getOutputs().upToDateWhen(reuseOutputs -> false);
+
+        return extractBuildInfoTask;
+    }
+
+    public static void addDeploymentTask(ExtractBuildInfoTask extractBuildInfoTask) {
+        Project project = extractBuildInfoTask.getProject();
+        Task task = project.getTasks().findByName(Constant.DEPLOY_TASK_NAME);
+        if (task instanceof DeployTask) {
+            return;
+        }
+        log.debug("Configuring {} task for root project {}", Constant.DEPLOY_TASK_NAME, project.getPath());
+
+        DeployTask deployTask = project.getTasks().create(Constant.DEPLOY_TASK_NAME, DeployTask.class);
+        deployTask.setDescription("Deploys artifacts and build-info to Artifactory.");
+        deployTask.setGroup(Constant.PUBLISH_TASK_GROUP);
+        deployTask.mustRunAfter(project.getTasks().withType(ExtractBuildInfoTask.class));
+        // always deploy after extracting - TODO: check if we need to also do it... maybe remove and change the deploy task name to artifactoryPublish, the collect will be new name?
+        extractBuildInfoTask.finalizedBy(deployTask);
+        // Extract when deploy
+         deployTask.dependsOn(extractBuildInfoTask);
+    }
+
+    /**
+     * Produce module info files if the module has publications to deploy from the collecting task
+     */
+    private static class DefaultModuleInfoFileProducer implements ModuleInfoFileProducer {
+        private final CollectDeployDetailsTask collectDeployDetailsTask;
+        private final ExtractModuleTask extractModuleTask;
+
+        DefaultModuleInfoFileProducer(CollectDeployDetailsTask collectDeployDetailsTask, ExtractModuleTask extractModuleTask) {
+            this.collectDeployDetailsTask = collectDeployDetailsTask;
+            this.extractModuleTask = extractModuleTask;
+        }
+
+        @Override
+        public boolean hasModules() {
+            if (collectDeployDetailsTask != null && collectDeployDetailsTask.getProject().getState().getExecuted()) {
+                return collectDeployDetailsTask.hasModules();
+            }
+            return false;
+        }
+
+        @Override
+        public FileCollection getModuleInfoFiles() {
+            return extractModuleTask.getOutputs().getFiles();
+        }
+    }
+}

--- a/src/main/java/org/jfrog/buildinfo/utils/TaskUtils.java
+++ b/src/main/java/org/jfrog/buildinfo/utils/TaskUtils.java
@@ -20,15 +20,14 @@ public class TaskUtils {
      * @return - task that was created for the given module
      */
     public static CollectDeployDetailsTask addCollectDeployDetailsTask(Project project) {
-        Task task = project.getTasks().findByName(Constant.ARTIFACTORY_PUBLISH_TASK_NAME);
+        Task task = project.getTasks().findByName(Constant.COLLECT_PUBLISH_INFO_TASK_NAME);
         if (task instanceof CollectDeployDetailsTask) {
             return (CollectDeployDetailsTask) task;
         }
-        log.debug("Configuring {} task for project (is root: {}) {}", Constant.ARTIFACTORY_PUBLISH_TASK_NAME, ProjectUtils.isRootProject(project), project.getPath());
+        log.debug("Configuring {} task for project (is root: {}) {}", Constant.COLLECT_PUBLISH_INFO_TASK_NAME, ProjectUtils.isRootProject(project), project.getPath());
 
-        CollectDeployDetailsTask collectDeployDetailsTask = project.getTasks().create(Constant.ARTIFACTORY_PUBLISH_TASK_NAME, CollectDeployDetailsTask.class);
+        CollectDeployDetailsTask collectDeployDetailsTask = project.getTasks().create(Constant.COLLECT_PUBLISH_INFO_TASK_NAME, CollectDeployDetailsTask.class);
         collectDeployDetailsTask.setDescription("Collect artifacts to be later used to generate build-info and deploy.");
-        collectDeployDetailsTask.setGroup(Constant.PUBLISH_TASK_GROUP);
 
         return collectDeployDetailsTask;
     }
@@ -42,18 +41,24 @@ public class TaskUtils {
         Project project = collectDeployDetailsTask.getProject();
         Task task = project.getTasks().findByName(Constant.EXTRACT_MODULE_TASK_NAME);
         if (!(task instanceof ExtractModuleTask)) {
-            log.debug("Configuring {} task for project (is root: {}) {}", Constant.EXTRACT_MODULE_TASK_NAME, ProjectUtils.isRootProject(project), project.getPath());
+            log.info("Configuring {} task for project (is root: {}) {}", Constant.EXTRACT_MODULE_TASK_NAME, ProjectUtils.isRootProject(project), project.getPath());
             task = project.getTasks().create(Constant.EXTRACT_MODULE_TASK_NAME, ExtractModuleTask.class);
-            task.setDescription("Extracts module info to an intermediate file.");
+            task.setDescription("Extracts module information to an intermediate file.");
+            task.setGroup(Constant.PUBLISH_TASK_GROUP);
         }
         ExtractModuleTask extractModuleTask = (ExtractModuleTask) task;
 
         extractModuleTask.getOutputs().upToDateWhen(reuseOutputs -> false);
         extractModuleTask.getModuleFile().set(project.getLayout().getBuildDirectory().file(Constant.MODULE_INFO_FILE_NAME));
-//        extractModuleTask.mustRunAfter(project.getTasks().withType(CollectDeployDetailsTask.class));
-        collectDeployDetailsTask.finalizedBy(extractModuleTask);
 
-        project.getRootProject().getTasks().withType(ExtractBuildInfoTask.class).configureEach(extractBuildInfoTask -> extractBuildInfoTask.registerModuleInfoProducer(new DefaultModuleInfoFileProducer(collectDeployDetailsTask, extractModuleTask)));
+        extractModuleTask.mustRunAfter(project.getTasks().withType(CollectDeployDetailsTask.class));
+        extractModuleTask.dependsOn(collectDeployDetailsTask);
+
+        project.getTasks().withType(ExtractBuildInfoTask.class).configureEach(extractBuildInfoTask ->
+        {
+            log.info("{} Registered info producer from {} + {}", extractBuildInfoTask.getPath(), collectDeployDetailsTask.getPath(), extractModuleTask.getPath());
+            extractBuildInfoTask.registerModuleInfoProducer(new DefaultModuleInfoFileProducer(collectDeployDetailsTask, extractModuleTask));
+        });
     }
 
     public static ExtractBuildInfoTask addExtractBuildInfoTask(Project project) {
@@ -61,11 +66,21 @@ public class TaskUtils {
         if (task instanceof ExtractBuildInfoTask) {
             return (ExtractBuildInfoTask) task;
         }
-        log.debug("Configuring {} task for root project {}", Constant.EXTRACT_BUILD_INFO_TASK_NAME, project.getPath());
+        log.info("Configuring {} task for project (is root: {}) {}", Constant.EXTRACT_BUILD_INFO_TASK_NAME, ProjectUtils.isRootProject(project), project.getPath());
 
         ExtractBuildInfoTask extractBuildInfoTask = project.getTasks().create(Constant.EXTRACT_BUILD_INFO_TASK_NAME, ExtractBuildInfoTask.class);
-        extractBuildInfoTask.setDescription("Extracts build info to a file.");
+        extractBuildInfoTask.setDescription("Extracts build-info to a file.");
+        extractBuildInfoTask.setGroup(Constant.PUBLISH_TASK_GROUP);
         extractBuildInfoTask.getOutputs().upToDateWhen(reuseOutputs -> false);
+
+        extractBuildInfoTask.mustRunAfter(project.getTasks().withType(ExtractModuleTask.class));
+        for (Project sub : project.getAllprojects()) {
+            Task extractModuleTask = sub.getTasks().findByName(Constant.EXTRACT_MODULE_TASK_NAME);
+            if (extractModuleTask instanceof ExtractModuleTask) {
+                extractBuildInfoTask.dependsOn(extractModuleTask);
+                log.info("{} depend on {}", extractBuildInfoTask.getPath(), extractModuleTask.getPath());
+            }
+        }
 
         return extractBuildInfoTask;
     }
@@ -76,16 +91,12 @@ public class TaskUtils {
         if (task instanceof DeployTask) {
             return;
         }
-        log.debug("Configuring {} task for root project {}", Constant.DEPLOY_TASK_NAME, project.getPath());
-
+        log.info("Configuring {} task for project (is root: {}) {}", Constant.DEPLOY_TASK_NAME, ProjectUtils.isRootProject(project), project.getPath());
         DeployTask deployTask = project.getTasks().create(Constant.DEPLOY_TASK_NAME, DeployTask.class);
         deployTask.setDescription("Deploys artifacts and build-info to Artifactory.");
         deployTask.setGroup(Constant.PUBLISH_TASK_GROUP);
-        deployTask.mustRunAfter(project.getTasks().withType(ExtractBuildInfoTask.class));
-        // always deploy after extracting - TODO: check if we need to also do it... maybe remove and change the deploy task name to artifactoryPublish, the collect will be new name?
-        extractBuildInfoTask.finalizedBy(deployTask);
-        // Extract when deploy
-         deployTask.dependsOn(extractBuildInfoTask);
+
+        deployTask.dependsOn(extractBuildInfoTask);
     }
 
     /**


### PR DESCRIPTION
Plugin tasks (No tasks are just for Root, all tasks are available to run from (only on) sub-modules as well):
* collectPublishInfo (group: 'other') - Collect artifacts to be later used to generate build-info and deploy.
* extractModuleInfo (group: 'publishing') - Extracts module information to an intermediate file.
* extractBuildInfo (group: 'publishing') - Extracts build-info to a file.
* artifactoryPublish (group: 'publishing') - Deploys artifacts and build-info to Artifactory.