### PR TITLE
Removing class path breaking change

### DIFF
--- a/src/functionalTest/resources/gradle-kts-example-publish/build.gradle.kts
+++ b/src/functionalTest/resources/gradle-kts-example-publish/build.gradle.kts
@@ -1,4 +1,4 @@
-import org.jfrog.gradle.plugin.artifactory.config.ArtifactoryPluginConvention
+import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask
 
 plugins {

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/ArtifactoryPlugin.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/ArtifactoryPlugin.java
@@ -6,7 +6,7 @@ import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.jfrog.build.client.Version;
-import org.jfrog.gradle.plugin.artifactory.config.ArtifactoryPluginConvention;
+import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention;
 import org.jfrog.gradle.plugin.artifactory.listener.ArtifactoryDependencyResolutionListener;
 import org.jfrog.gradle.plugin.artifactory.listener.ProjectsEvaluatedBuildListener;
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask;

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/dsl/ArtifactoryPluginConvention.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/dsl/ArtifactoryPluginConvention.java
@@ -1,4 +1,4 @@
-package org.jfrog.gradle.plugin.artifactory.config;
+package org.jfrog.gradle.plugin.artifactory.dsl;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/dsl/PropertiesConfig.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/dsl/PropertiesConfig.java
@@ -1,4 +1,4 @@
-package org.jfrog.gradle.plugin.artifactory.config;
+package org.jfrog.gradle.plugin.artifactory.dsl;
 
 import groovy.lang.GroovyObjectSupport;
 import org.gradle.api.GradleException;

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/dsl/PublisherConfig.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/dsl/PublisherConfig.java
@@ -1,4 +1,4 @@
-package org.jfrog.gradle.plugin.artifactory.config;
+package org.jfrog.gradle.plugin.artifactory.dsl;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/GradleDeployDetails.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/GradleDeployDetails.java
@@ -1,4 +1,4 @@
-package org.jfrog.gradle.plugin.artifactory.extractor.details;
+package org.jfrog.gradle.plugin.artifactory.extractor;
 
 import org.gradle.api.Project;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/GradleModuleExtractor.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/GradleModuleExtractor.java
@@ -18,8 +18,6 @@ import org.jfrog.build.extractor.ci.Module;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
 import org.jfrog.gradle.plugin.artifactory.ArtifactoryPlugin;
-import org.jfrog.gradle.plugin.artifactory.extractor.details.GradleDeployDetails;
-import org.jfrog.gradle.plugin.artifactory.extractor.details.PublishArtifactInfo;
 import org.jfrog.gradle.plugin.artifactory.listener.ArtifactoryDependencyResolutionListener;
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask;
 import org.jfrog.gradle.plugin.artifactory.utils.ConventionUtils;

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/PublishArtifactInfo.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/PublishArtifactInfo.java
@@ -1,4 +1,4 @@
-package org.jfrog.gradle.plugin.artifactory.extractor.details;
+package org.jfrog.gradle.plugin.artifactory.extractor;
 
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.GradleException;

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/listener/ProjectsEvaluatedBuildListener.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/listener/ProjectsEvaluatedBuildListener.java
@@ -12,7 +12,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.publish.PublishingExtension;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
-import org.jfrog.gradle.plugin.artifactory.config.ArtifactoryPluginConvention;
+import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention;
 import org.jfrog.gradle.plugin.artifactory.Constant;
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask;
 import org.jfrog.gradle.plugin.artifactory.utils.ConventionUtils;

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
@@ -27,10 +27,10 @@ import org.gradle.util.ConfigureUtil;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactSpecs;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 import org.jfrog.gradle.plugin.artifactory.Constant;
-import org.jfrog.gradle.plugin.artifactory.config.ArtifactoryPluginConvention;
-import org.jfrog.gradle.plugin.artifactory.config.PropertiesConfig;
-import org.jfrog.gradle.plugin.artifactory.config.PublisherConfig;
-import org.jfrog.gradle.plugin.artifactory.extractor.details.GradleDeployDetails;
+import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention;
+import org.jfrog.gradle.plugin.artifactory.dsl.PropertiesConfig;
+import org.jfrog.gradle.plugin.artifactory.dsl.PublisherConfig;
+import org.jfrog.gradle.plugin.artifactory.extractor.GradleDeployDetails;
 import org.jfrog.gradle.plugin.artifactory.utils.ConventionUtils;
 import org.jfrog.gradle.plugin.artifactory.utils.PublicationUtils;
 

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/ConventionUtils.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/ConventionUtils.java
@@ -8,7 +8,7 @@ import org.jfrog.build.api.util.CommonUtils;
 import org.jfrog.build.extractor.BuildInfoExtractorUtils;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 import org.jfrog.gradle.plugin.artifactory.Constant;
-import org.jfrog.gradle.plugin.artifactory.config.ArtifactoryPluginConvention;
+import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention;
 
 import java.util.Map;
 import java.util.Properties;

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/DeployUtils.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/DeployUtils.java
@@ -12,7 +12,7 @@ import org.jfrog.build.extractor.clientConfiguration.client.artifactory.Artifact
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployableArtifactsUtils;
 import org.jfrog.build.extractor.retention.Utils;
-import org.jfrog.gradle.plugin.artifactory.extractor.details.GradleDeployDetails;
+import org.jfrog.gradle.plugin.artifactory.extractor.GradleDeployDetails;
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask;
 
 import java.io.File;

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/ProjectUtils.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/ProjectUtils.java
@@ -7,7 +7,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
 import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
-import org.jfrog.gradle.plugin.artifactory.extractor.details.GradleDeployDetails;
+import org.jfrog.gradle.plugin.artifactory.extractor.GradleDeployDetails;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/PublicationUtils.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/PublicationUtils.java
@@ -25,8 +25,8 @@ import org.jfrog.build.extractor.clientConfiguration.ArtifactSpec;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 import org.jfrog.build.extractor.clientConfiguration.LayoutPatterns;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
-import org.jfrog.gradle.plugin.artifactory.extractor.details.GradleDeployDetails;
-import org.jfrog.gradle.plugin.artifactory.extractor.details.PublishArtifactInfo;
+import org.jfrog.gradle.plugin.artifactory.extractor.GradleDeployDetails;
+import org.jfrog.gradle.plugin.artifactory.extractor.PublishArtifactInfo;
 import org.jfrog.gradle.plugin.artifactory.Constant;
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask;
 

--- a/src/test/java/org/jfrog/gradle/plugin/artifactory/PropertiesConfigTest.java
+++ b/src/test/java/org/jfrog/gradle/plugin/artifactory/PropertiesConfigTest.java
@@ -8,7 +8,7 @@ import org.gradle.api.logging.Logging;
 import org.gradle.internal.metaobject.DynamicInvokeResult;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactSpec;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactSpecs;
-import org.jfrog.gradle.plugin.artifactory.config.PropertiesConfig;
+import org.jfrog.gradle.plugin.artifactory.dsl.PropertiesConfig;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 


### PR DESCRIPTION
- [ ] All [tests](../CONTRIBUTING.md) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

Changing inner classes packages names back to the original names to avoid breaking. 

* class `org.jfrog.gradle.plugin.artifactory.extractor.details.GradleDeployDetails` moved to `org.jfrog.gradle.plugin.artifactory.extractor.GradleDeployDetails`
* `org.jfrog.gradle.plugin.artifactory.extractor.details.PublishArtifactInfo` moved to `org.jfrog.gradle.plugin.artifactory.extractor.PublishArtifactInfo`
* package `org.jfrog.gradle.plugin.artifactory.config` changed to: `org.jfrog.gradle.plugin.artifactory.dsl`
