### PR TITLE
Remove registration of listener on 'Gradle.addListener'

### DIFF
--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/ArtifactoryPlugin.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/ArtifactoryPlugin.java
@@ -34,7 +34,8 @@ public class ArtifactoryPlugin implements Plugin<Project> {
             // Add extract build-info and deploy task for the root to only deploy one time
             TaskUtils.addDeploymentTask(project);
             // Add a DependencyResolutionListener, to populate the dependency hierarchy map.
-            project.getGradle().addListener(resolutionListener);
+            project.getAllprojects().forEach(subproject ->
+                    subproject.getConfigurations().all(config -> config.getIncoming().afterResolve(resolutionListener::afterResolve)));
         } else {
             // Makes sure the plugin is applied in the root project
             project.getRootProject().getPluginManager().apply(ArtifactoryPlugin.class);

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/listener/ArtifactoryDependencyResolutionListener.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/listener/ArtifactoryDependencyResolutionListener.java
@@ -1,6 +1,5 @@
 package org.jfrog.gradle.plugin.artifactory.listener;
 
-import org.gradle.api.artifacts.DependencyResolutionListener;
 import org.gradle.api.artifacts.ResolvableDependencies;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
@@ -10,17 +9,12 @@ import org.jfrog.gradle.plugin.artifactory.utils.ProjectUtils;
 import java.util.*;
 
 /**
- * Represents a DependencyResolutionListener, used to populate a dependency hierarchy map for each dependency in each module,
+ * Populate a dependency hierarchy map for each dependency in each module,
  * which is used in the 'requestedBy' field of every dependency in the build info, by listening to the 'afterResolve' event of every module.
  */
-public class ArtifactoryDependencyResolutionListener implements DependencyResolutionListener {
+public class ArtifactoryDependencyResolutionListener {
     private final Map<String, Map<String, String[][]>> modulesHierarchyMap = new HashMap<>();
 
-    @Override
-    public void beforeResolve(ResolvableDependencies dependencies) {
-    }
-
-    @Override
     public void afterResolve(ResolvableDependencies dependencies) {
         if (!dependencies.getResolutionResult().getAllDependencies().isEmpty()) {
             updateModulesMap(dependencies);


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

https://github.com/jfrog/build-info/issues/601
Remove the registration of DependencyResolutionListener and register a listener separately for each resolved configuration.
That should allow using the plugin with configuration cache in Gradle 7.