### PR TITLE
Cannot set the value of read-only property 'publishBuildInfo'

### DIFF
--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/dsl/PublisherConfig.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/dsl/PublisherConfig.java
@@ -52,7 +52,7 @@ public class PublisherConfig {
     }
 
     @SuppressWarnings("unused")
-    public void publishBuildInfo(boolean publishBuildInfo) {
+    public void setPublishBuildInfo(boolean publishBuildInfo) {
         this.publisher.setPublishBuildInfo(publishBuildInfo);
     }
 


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md) passed. If this feature is not already covered by the tests, I added new
  tests.

-----
