### PR TITLE
Fix deployable artifacts mechanism

### DIFF
--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/PluginAndroidTest.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/PluginAndroidTest.java
@@ -26,8 +26,8 @@ public class PluginAndroidTest extends GradleFunctionalTestBase {
 
     @Test
     public void androidCiTest() throws IOException {
-        runPublishCITest(GRADLE_ANDROID_VERSION, TestConstant.ANDROID_GRADLE_CI_EXAMPLE, true, () -> Utils.generateBuildInfoProperties(this, "", true, true),
-                this::checkBuildResults);
+        runPublishCITest(GRADLE_ANDROID_VERSION, TestConstant.ANDROID_GRADLE_CI_EXAMPLE, true, (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "", true, true, ""),
+                (buildResult, deployableArtifacts) -> checkBuildResults(buildResult));
     }
 
     /**

--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/PluginBomPublishTest.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/PluginBomPublishTest.java
@@ -16,16 +16,16 @@ public class PluginBomPublishTest extends GradleFunctionalTestBase {
     @Test(dataProvider = "gradleVersions")
     public void publishDefaultBomTest(String gradleVersion) throws IOException {
         runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_DEFAULT_BOM, true,
-                () -> Utils.generateBuildInfoProperties(this, "", true, true),
-                buildResult -> ValidationUtils.checkBomBuild(buildResult, TestConstant.BUILD_INFO_JSON.toFile(), 2)
+                (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "", true, true, ""),
+                (buildResult, deployableArtifacts) -> ValidationUtils.checkBomBuild(buildResult, TestConstant.BUILD_INFO_JSON.toFile(), 2)
         );
     }
 
     @Test(dataProvider = "gradleVersions")
     public void publishCustomBomTest(String gradleVersion) throws IOException {
         runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_CUSTOM_BOM, true,
-                () -> Utils.generateBuildInfoProperties(this, "customMavenJavaPlatform", true, true),
-                buildResult -> ValidationUtils.checkBomBuild(buildResult, TestConstant.BUILD_INFO_JSON.toFile(), 2)
+                (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "customMavenJavaPlatform", true, true, ""),
+                (buildResult, deployableArtifacts) -> ValidationUtils.checkBomBuild(buildResult, TestConstant.BUILD_INFO_JSON.toFile(), 2)
         );
     }
 }

--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/PluginCiPublishTest.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/PluginCiPublishTest.java
@@ -17,40 +17,40 @@ public class PluginCiPublishTest extends GradleFunctionalTestBase {
     @Test(dataProvider = "gradleVersions")
     public void ciServerTest(String gradleVersion) throws IOException {
         runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_CI_SERVER, true,
-                () -> Utils.generateBuildInfoProperties(this, "", true, true),
-                buildResult -> ValidationUtils.checkBuildResults(artifactoryManager, buildResult, localRepo)
+                (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "", true, true, deployableArtifacts),
+                (buildResult, deployableArtifacts) -> ValidationUtils.checkBuildResults(artifactoryManager, buildResult, localRepo, deployableArtifacts)
         );
     }
 
     @Test(dataProvider = "gradleVersions")
     public void ciServerResolverOnlyTest(String gradleVersion) throws IOException {
         runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_CI_SERVER, false,
-                () -> Utils.generateBuildInfoProperties(this, "", false, false),
-                buildResult -> ValidationUtils.checkLocalBuild(buildResult, TestConstant.BUILD_INFO_JSON.toFile(), 2, 0)
+                (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "", false, false, ""),
+                (buildResult, deployableArtifacts) -> ValidationUtils.checkLocalBuild(buildResult, TestConstant.BUILD_INFO_JSON.toFile(), 2, 0)
         );
     }
 
     @Test(dataProvider = "gradleVersions")
     public void ciServerPublicationsTest(String gradleVersion) throws IOException {
         runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_CI_SERVER, true,
-                () -> Utils.generateBuildInfoProperties(this, "mavenJava,customIvyPublication", true, true),
-                buildResult -> ValidationUtils.checkBuildResults(artifactoryManager, buildResult, localRepo)
+                (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "mavenJava,customIvyPublication", true, true, deployableArtifacts),
+                (buildResult, deployableArtifacts) -> ValidationUtils.checkBuildResults(artifactoryManager, buildResult, localRepo, deployableArtifacts)
         );
     }
 
     @Test(dataProvider = "gradleVersions")
     public void ciRequestedByTest(String gradleVersion) throws IOException {
         runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_CI_SERVER, false,
-                () -> Utils.generateBuildInfoProperties(this, "mavenJava,customIvyPublication", false, true),
-                buildResult -> ValidationUtils.checkLocalBuild(buildResult, TestConstant.BUILD_INFO_JSON.toFile(), 3, 5)
+                (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "mavenJava,customIvyPublication", false, true, ""),
+                (buildResult, deployableArtifacts) -> ValidationUtils.checkLocalBuild(buildResult, TestConstant.BUILD_INFO_JSON.toFile(), 3, 5)
         );
     }
 
     @Test(dataProvider = "gradleVersions")
     public void ciServerArchivesTest(String gradleVersion) throws IOException {
         runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_CI_SERVER_ARCHIVES, true,
-                () -> Utils.generateBuildInfoProperties(this, "", true, true),
-                buildResult -> ValidationUtils.checkArchivesBuildResults(artifactoryManager, buildResult, localRepo)
+                (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "", true, true, ""),
+                (buildResult, deployableArtifacts) -> ValidationUtils.checkArchivesBuildResults(artifactoryManager, buildResult, localRepo)
         );
     }
 
@@ -60,13 +60,13 @@ public class PluginCiPublishTest extends GradleFunctionalTestBase {
             throw new SkipException("Version catalog test requires at least Gradle version " + MIN_GRADLE_VERSION_CATALOG_VERSION);
         }
         runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_VERSION_CATALOG_PRODUCER, false,
-                () -> Utils.generateBuildInfoProperties(this, "versionCatalogProducer", false, true),
-                buildResult -> ValidationUtils.verifyArtifacts(artifactoryManager, localRepo + "/", EXPECTED_VERSION_CATALOG_PRODUCER_ARTIFACTS)
+                (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "versionCatalogProducer", false, true, ""),
+                (buildResult, deployableArtifacts) -> ValidationUtils.verifyArtifacts(artifactoryManager, localRepo + "/", EXPECTED_VERSION_CATALOG_PRODUCER_ARTIFACTS)
         );
 
         runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_VERSION_CATALOG_CONSUMER, true,
-                () -> Utils.generateBuildInfoProperties(this, "versionCatalogConsumer", true, true),
-                buildResult -> ValidationUtils.checkVersionCatalogResults(artifactoryManager, buildResult, virtualRepo)
+                (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "versionCatalogConsumer", true, true, ""),
+                (buildResult, deployableArtifacts) -> ValidationUtils.checkVersionCatalogResults(artifactoryManager, buildResult, virtualRepo)
         );
     }
 }

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/DeployUtils.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/DeployUtils.java
@@ -56,14 +56,14 @@ public class DeployUtils {
                 log.debug("Task '{}' does not have publisher configured with contextUrl attribute", artifactoryTask.getPath());
                 return;
             }
+            mergeRootAndModuleProps(taskPublisher, propsRoot);
+            // Add the task deployed details to the container of all deployed details
+            allDeployDetails.put(artifactoryTask.getProject().getName(), getTaskDeployDetails(artifactoryTask));
             if (!taskPublisher.isPublishArtifacts()) {
                 log.debug("Task '{}' configured not to deploy artifacts", artifactoryTask.getPath());
                 return;
             }
-            mergeRootAndModuleProps(taskPublisher, propsRoot);
             configureArtifactoryManagerAndDeploy(accRoot, taskPublisher, artifactoryTask.getDeployDetails(), logPrefix);
-            // Add the task deployed details to the container of all deployed details
-            allDeployDetails.put(artifactoryTask.getProject().getName(), getTaskDeployDetails(artifactoryTask));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

Currently, the deployable artifacts mechanism adds the deployable artifacts only if the artifacts are deployed. However, there's a requirement for these deployable artifacts even when they haven't been deployed yet, so we can deploy them at a later time. For instance, the command `jf gradle clean aP --scan` is used to analyze the deployable artifacts and then deploy the ones that are non-vulnerable.

This PR make it work like v4 of this plugin: https://github.com/jfrog/build-info/blob/build-info-gradle-extractor-4.33.4/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java#L193