### PR TITLE
Support Gradle configuration cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
+        java-version: [ "8", "11" ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -24,7 +25,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "8"
+          java-version: ${{ matrix.java-version }}
 
       - name: Setup Artifactory
         env:

--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/GradleFunctionalTestBase.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/GradleFunctionalTestBase.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
 import static org.jfrog.gradle.plugin.artifactory.Constant.*;
-import static org.jfrog.gradle.plugin.artifactory.TestConstant.MIN_GRADLE_VERSION_CONFIG_CACHE;
+import static org.jfrog.gradle.plugin.artifactory.TestConsts.MIN_GRADLE_VERSION_CONFIG_CACHE;
 import static org.jfrog.gradle.plugin.artifactory.utils.Utils.createDeployableArtifactsFile;
 import static org.testng.Assert.assertEquals;
 
@@ -42,9 +42,9 @@ public class GradleFunctionalTestBase {
     private String artifactoryUrl;
 
     // Test repositories
-    public final String localRepo = getKeyWithTimestamp(TestConstant.GRADLE_LOCAL_REPO);
-    public final String virtualRepo = getKeyWithTimestamp(TestConstant.GRADLE_VIRTUAL_REPO);
-    protected String remoteRepo = getKeyWithTimestamp(TestConstant.GRADLE_REMOTE_REPO);
+    public final String localRepo = getKeyWithTimestamp(TestConsts.GRADLE_LOCAL_REPO);
+    public final String virtualRepo = getKeyWithTimestamp(TestConsts.GRADLE_VIRTUAL_REPO);
+    protected String remoteRepo = getKeyWithTimestamp(TestConsts.GRADLE_REMOTE_REPO);
 
     // Test specific attributes
     private StringSubstitutor stringSubstitutor;
@@ -109,7 +109,7 @@ public class GradleFunctionalTestBase {
         Path deployableArtifacts = createDeployableArtifactsFile();
         testEnvCreator.create(deployableArtifacts.toString());
         Map<String, String> extendedEnv = new HashMap<String, String>(envVars) {{
-            put(BuildInfoConfigProperties.PROP_PROPS_FILE, TestConstant.BUILD_INFO_PROPERTIES_TARGET.toString());
+            put(BuildInfoConfigProperties.PROP_PROPS_FILE, TestConsts.BUILD_INFO_PROPERTIES_TARGET.toString());
             put(RESOLUTION_URL_ENV, getArtifactoryUrl() + virtualRepo);
             put(RESOLUTION_USERNAME_ENV, getUsername());
             put(RESOLUTION_PASSWORD_ENV, getAdminToken());
@@ -150,14 +150,14 @@ public class GradleFunctionalTestBase {
 
     private void initArtifactoryManager() {
         // URL
-        platformUrl = Utils.readParam(TestConstant.URL, TestConstant.DEFAULT_URL);
+        platformUrl = Utils.readParam(TestConsts.URL, TestConsts.DEFAULT_URL);
         if (!platformUrl.endsWith("/")) {
             platformUrl += "/";
         }
         artifactoryUrl = platformUrl + Constant.ARTIFACTORY + "/";
         // Credentials
-        username = Utils.readParam(TestConstant.USERNAME, TestConstant.DEFAULT_USERNAME);
-        adminToken = Utils.readParam(TestConstant.ADMIN_TOKEN, TestConstant.DEFAULT_PASS);
+        username = Utils.readParam(TestConsts.USERNAME, TestConsts.DEFAULT_USERNAME);
+        adminToken = Utils.readParam(TestConsts.ADMIN_TOKEN, TestConsts.DEFAULT_PASS);
         // Create
         artifactoryManager = createArtifactoryManager();
     }
@@ -181,8 +181,8 @@ public class GradleFunctionalTestBase {
 
     private void createStringSubstitutor() {
         Map<String, Object> textParameters = new HashMap<>();
-        textParameters.put(TestConstant.LOCAL_REPO, localRepo);
-        textParameters.put(TestConstant.REMOTE_REPO, remoteRepo);
+        textParameters.put(TestConsts.LOCAL_REPO, localRepo);
+        textParameters.put(TestConsts.REMOTE_REPO, remoteRepo);
         stringSubstitutor = new StringSubstitutor(textParameters);
     }
 
@@ -224,11 +224,11 @@ public class GradleFunctionalTestBase {
     private void initGradleCmdEnvVars() {
         // Create env vars to pass for running gradle commands (var replacement in build.gradle files?
         envVars = new HashMap<String, String>(System.getenv()) {{
-            putIfAbsent(TestConstant.BITESTS_ENV_VAR_PREFIX + TestConstant.URL, getPlatformUrl());
-            putIfAbsent(TestConstant.BITESTS_ENV_VAR_PREFIX + TestConstant.USERNAME, getUsername());
-            putIfAbsent(TestConstant.BITESTS_ENV_VAR_PREFIX + TestConstant.ADMIN_TOKEN, getAdminToken());
-            putIfAbsent(TestConstant.BITESTS_ARTIFACTORY_ENV_VAR_PREFIX + TestConstant.LOCAL_REPO, localRepo);
-            putIfAbsent(TestConstant.BITESTS_ARTIFACTORY_ENV_VAR_PREFIX + TestConstant.VIRTUAL_REPO, virtualRepo);
+            putIfAbsent(TestConsts.BITESTS_ENV_VAR_PREFIX + TestConsts.URL, getPlatformUrl());
+            putIfAbsent(TestConsts.BITESTS_ENV_VAR_PREFIX + TestConsts.USERNAME, getUsername());
+            putIfAbsent(TestConsts.BITESTS_ENV_VAR_PREFIX + TestConsts.ADMIN_TOKEN, getAdminToken());
+            putIfAbsent(TestConsts.BITESTS_ARTIFACTORY_ENV_VAR_PREFIX + TestConsts.LOCAL_REPO, localRepo);
+            putIfAbsent(TestConsts.BITESTS_ARTIFACTORY_ENV_VAR_PREFIX + TestConsts.VIRTUAL_REPO, virtualRepo);
         }};
     }
 
@@ -250,7 +250,7 @@ public class GradleFunctionalTestBase {
      * @throws IOException - In case of any IO error
      */
     protected static void deleteTestDir() throws IOException {
-        FileUtils.deleteDirectory(TestConstant.TEST_DIR);
+        FileUtils.deleteDirectory(TestConsts.TEST_DIR);
     }
 
     /**

--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/TestConstant.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/TestConstant.java
@@ -1,5 +1,7 @@
 package org.jfrog.gradle.plugin.artifactory;
 
+import org.jfrog.build.client.Version;
+
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -60,6 +62,9 @@ public class TestConstant {
 
     // Version catalog
     public static final String MIN_GRADLE_VERSION_CATALOG_VERSION = "7.0";
+
+    // Configuration cache
+    public static final Version MIN_GRADLE_VERSION_CONFIG_CACHE = new Version("7.4.2");
 
     // Results
     public static final String ARTIFACTS_GROUP_ID = "/org/jfrog/test/gradle/publish/";

--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/TestConsts.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/TestConsts.java
@@ -8,7 +8,7 @@ import java.nio.file.Paths;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-public class TestConstant {
+public class TestConsts {
     // Root paths
     public static final Path GRADLE_EXTRACTOR = Paths.get(".").normalize().toAbsolutePath();
     public static final Path GRADLE_EXTRACTOR_SRC = GRADLE_EXTRACTOR.resolve("src");

--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/PluginAndroidTest.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/PluginAndroidTest.java
@@ -7,6 +7,8 @@ import org.jfrog.build.extractor.ci.Module;
 import org.jfrog.gradle.plugin.artifactory.GradleFunctionalTestBase;
 import org.jfrog.gradle.plugin.artifactory.TestConsts;
 import org.jfrog.gradle.plugin.artifactory.utils.Utils;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -19,6 +21,15 @@ import static org.jfrog.gradle.plugin.artifactory.utils.ValidationUtils.getBuild
 import static org.testng.Assert.*;
 
 public class PluginAndroidTest extends GradleFunctionalTestBase {
+
+    @BeforeMethod
+    public void checkJavaVersion() {
+        String javaVersion = System.getProperty("java.version");
+        if (javaVersion.startsWith("1.8")) {
+            throw new SkipException("Skipping Android test on Java 8");
+        }
+    }
+
     @Test
     public void androidTest() throws IOException {
         runPublishTest(GRADLE_ANDROID_VERSION, TestConsts.ANDROID_GRADLE_EXAMPLE, this::checkBuildResults);

--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/PluginAndroidTest.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/PluginAndroidTest.java
@@ -5,7 +5,7 @@ import org.jfrog.build.api.dependency.PropertySearchResult;
 import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.extractor.ci.Module;
 import org.jfrog.gradle.plugin.artifactory.GradleFunctionalTestBase;
-import org.jfrog.gradle.plugin.artifactory.TestConstant;
+import org.jfrog.gradle.plugin.artifactory.TestConsts;
 import org.jfrog.gradle.plugin.artifactory.utils.Utils;
 import org.testng.annotations.Test;
 
@@ -13,20 +13,20 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.gradle.testkit.runner.TaskOutcome.FAILED;
-import static org.jfrog.gradle.plugin.artifactory.TestConstant.EXPECTED_ANDROID_ARTIFACTS;
-import static org.jfrog.gradle.plugin.artifactory.TestConstant.GRADLE_ANDROID_VERSION;
+import static org.jfrog.gradle.plugin.artifactory.TestConsts.EXPECTED_ANDROID_ARTIFACTS;
+import static org.jfrog.gradle.plugin.artifactory.TestConsts.GRADLE_ANDROID_VERSION;
 import static org.jfrog.gradle.plugin.artifactory.utils.ValidationUtils.getBuildInfo;
 import static org.testng.Assert.*;
 
 public class PluginAndroidTest extends GradleFunctionalTestBase {
     @Test
     public void androidTest() throws IOException {
-        runPublishTest(GRADLE_ANDROID_VERSION, TestConstant.ANDROID_GRADLE_EXAMPLE, this::checkBuildResults);
+        runPublishTest(GRADLE_ANDROID_VERSION, TestConsts.ANDROID_GRADLE_EXAMPLE, this::checkBuildResults);
     }
 
     @Test
     public void androidCiTest() throws IOException {
-        runPublishCITest(GRADLE_ANDROID_VERSION, TestConstant.ANDROID_GRADLE_CI_EXAMPLE, true, (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "", true, true, ""),
+        runPublishCITest(GRADLE_ANDROID_VERSION, TestConsts.ANDROID_GRADLE_CI_EXAMPLE, true, (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "", true, true, ""),
                 (buildResult, deployableArtifacts) -> checkBuildResults(buildResult));
     }
 

--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/PluginBomPublishTest.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/PluginBomPublishTest.java
@@ -1,7 +1,7 @@
 package org.jfrog.gradle.plugin.artifactory.tests;
 
 import org.jfrog.gradle.plugin.artifactory.GradleFunctionalTestBase;
-import org.jfrog.gradle.plugin.artifactory.TestConstant;
+import org.jfrog.gradle.plugin.artifactory.TestConsts;
 import org.jfrog.gradle.plugin.artifactory.utils.Utils;
 import org.jfrog.gradle.plugin.artifactory.utils.ValidationUtils;
 import org.testng.annotations.Test;
@@ -15,17 +15,17 @@ public class PluginBomPublishTest extends GradleFunctionalTestBase {
 
     @Test(dataProvider = "gradleVersions")
     public void publishDefaultBomTest(String gradleVersion) throws IOException {
-        runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_DEFAULT_BOM, true,
+        runPublishCITest(gradleVersion, TestConsts.GRADLE_EXAMPLE_DEFAULT_BOM, true,
                 (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "", true, true, ""),
-                (buildResult, deployableArtifacts) -> ValidationUtils.checkBomBuild(buildResult, TestConstant.BUILD_INFO_JSON.toFile(), 2)
+                (buildResult, deployableArtifacts) -> ValidationUtils.checkBomBuild(buildResult, TestConsts.BUILD_INFO_JSON.toFile(), 2)
         );
     }
 
     @Test(dataProvider = "gradleVersions")
     public void publishCustomBomTest(String gradleVersion) throws IOException {
-        runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_CUSTOM_BOM, true,
+        runPublishCITest(gradleVersion, TestConsts.GRADLE_EXAMPLE_CUSTOM_BOM, true,
                 (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "customMavenJavaPlatform", true, true, ""),
-                (buildResult, deployableArtifacts) -> ValidationUtils.checkBomBuild(buildResult, TestConstant.BUILD_INFO_JSON.toFile(), 2)
+                (buildResult, deployableArtifacts) -> ValidationUtils.checkBomBuild(buildResult, TestConsts.BUILD_INFO_JSON.toFile(), 2)
         );
     }
 }

--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/PluginCiPublishTest.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/PluginCiPublishTest.java
@@ -2,7 +2,7 @@ package org.jfrog.gradle.plugin.artifactory.tests;
 
 import org.jfrog.build.client.Version;
 import org.jfrog.gradle.plugin.artifactory.GradleFunctionalTestBase;
-import org.jfrog.gradle.plugin.artifactory.TestConstant;
+import org.jfrog.gradle.plugin.artifactory.TestConsts;
 import org.jfrog.gradle.plugin.artifactory.utils.Utils;
 import org.jfrog.gradle.plugin.artifactory.utils.ValidationUtils;
 import org.testng.SkipException;
@@ -10,13 +10,13 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 
-import static org.jfrog.gradle.plugin.artifactory.TestConstant.EXPECTED_VERSION_CATALOG_PRODUCER_ARTIFACTS;
-import static org.jfrog.gradle.plugin.artifactory.TestConstant.MIN_GRADLE_VERSION_CATALOG_VERSION;
+import static org.jfrog.gradle.plugin.artifactory.TestConsts.EXPECTED_VERSION_CATALOG_PRODUCER_ARTIFACTS;
+import static org.jfrog.gradle.plugin.artifactory.TestConsts.MIN_GRADLE_VERSION_CATALOG_VERSION;
 
 public class PluginCiPublishTest extends GradleFunctionalTestBase {
     @Test(dataProvider = "gradleVersions")
     public void ciServerTest(String gradleVersion) throws IOException {
-        runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_CI_SERVER, true,
+        runPublishCITest(gradleVersion, TestConsts.GRADLE_EXAMPLE_CI_SERVER, true,
                 (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "", true, true, deployableArtifacts),
                 (buildResult, deployableArtifacts) -> ValidationUtils.checkBuildResults(artifactoryManager, buildResult, localRepo, deployableArtifacts)
         );
@@ -24,15 +24,15 @@ public class PluginCiPublishTest extends GradleFunctionalTestBase {
 
     @Test(dataProvider = "gradleVersions")
     public void ciServerResolverOnlyTest(String gradleVersion) throws IOException {
-        runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_CI_SERVER, false,
+        runPublishCITest(gradleVersion, TestConsts.GRADLE_EXAMPLE_CI_SERVER, false,
                 (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "", false, false, ""),
-                (buildResult, deployableArtifacts) -> ValidationUtils.checkLocalBuild(buildResult, TestConstant.BUILD_INFO_JSON.toFile(), 2, 0)
+                (buildResult, deployableArtifacts) -> ValidationUtils.checkLocalBuild(buildResult, TestConsts.BUILD_INFO_JSON.toFile(), 2, 0)
         );
     }
 
     @Test(dataProvider = "gradleVersions")
     public void ciServerPublicationsTest(String gradleVersion) throws IOException {
-        runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_CI_SERVER, true,
+        runPublishCITest(gradleVersion, TestConsts.GRADLE_EXAMPLE_CI_SERVER, true,
                 (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "mavenJava,customIvyPublication", true, true, deployableArtifacts),
                 (buildResult, deployableArtifacts) -> ValidationUtils.checkBuildResults(artifactoryManager, buildResult, localRepo, deployableArtifacts)
         );
@@ -40,15 +40,15 @@ public class PluginCiPublishTest extends GradleFunctionalTestBase {
 
     @Test(dataProvider = "gradleVersions")
     public void ciRequestedByTest(String gradleVersion) throws IOException {
-        runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_CI_SERVER, false,
+        runPublishCITest(gradleVersion, TestConsts.GRADLE_EXAMPLE_CI_SERVER, false,
                 (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "mavenJava,customIvyPublication", false, true, ""),
-                (buildResult, deployableArtifacts) -> ValidationUtils.checkLocalBuild(buildResult, TestConstant.BUILD_INFO_JSON.toFile(), 3, 5)
+                (buildResult, deployableArtifacts) -> ValidationUtils.checkLocalBuild(buildResult, TestConsts.BUILD_INFO_JSON.toFile(), 3, 5)
         );
     }
 
     @Test(dataProvider = "gradleVersions")
     public void ciServerArchivesTest(String gradleVersion) throws IOException {
-        runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_CI_SERVER_ARCHIVES, true,
+        runPublishCITest(gradleVersion, TestConsts.GRADLE_EXAMPLE_CI_SERVER_ARCHIVES, true,
                 (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "", true, true, ""),
                 (buildResult, deployableArtifacts) -> ValidationUtils.checkArchivesBuildResults(artifactoryManager, buildResult, localRepo)
         );
@@ -59,12 +59,12 @@ public class PluginCiPublishTest extends GradleFunctionalTestBase {
         if (!new Version(gradleVersion).isAtLeast(new Version(MIN_GRADLE_VERSION_CATALOG_VERSION))) {
             throw new SkipException("Version catalog test requires at least Gradle version " + MIN_GRADLE_VERSION_CATALOG_VERSION);
         }
-        runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_VERSION_CATALOG_PRODUCER, false,
+        runPublishCITest(gradleVersion, TestConsts.GRADLE_EXAMPLE_VERSION_CATALOG_PRODUCER, false,
                 (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "versionCatalogProducer", false, true, ""),
                 (buildResult, deployableArtifacts) -> ValidationUtils.verifyArtifacts(artifactoryManager, localRepo + "/", EXPECTED_VERSION_CATALOG_PRODUCER_ARTIFACTS)
         );
 
-        runPublishCITest(gradleVersion, TestConstant.GRADLE_EXAMPLE_VERSION_CATALOG_CONSUMER, true,
+        runPublishCITest(gradleVersion, TestConsts.GRADLE_EXAMPLE_VERSION_CATALOG_CONSUMER, true,
                 (deployableArtifacts) -> Utils.generateBuildInfoProperties(this, "versionCatalogConsumer", true, true, ""),
                 (buildResult, deployableArtifacts) -> ValidationUtils.checkVersionCatalogResults(artifactoryManager, buildResult, virtualRepo)
         );

--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/PluginPublishTest.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/PluginPublishTest.java
@@ -1,7 +1,7 @@
 package org.jfrog.gradle.plugin.artifactory.tests;
 
 import org.jfrog.gradle.plugin.artifactory.GradleFunctionalTestBase;
-import org.jfrog.gradle.plugin.artifactory.TestConstant;
+import org.jfrog.gradle.plugin.artifactory.TestConsts;
 import org.jfrog.gradle.plugin.artifactory.utils.ValidationUtils;
 import org.testng.annotations.Test;
 
@@ -10,7 +10,7 @@ import java.io.IOException;
 public class PluginPublishTest extends GradleFunctionalTestBase {
     @Test(dataProvider = "gradleVersions")
     public void publicationsTest(String gradleVersion) throws IOException {
-        runPublishTest(gradleVersion, TestConstant.GRADLE_EXAMPLE_PUBLISH, buildResult -> {
+        runPublishTest(gradleVersion, TestConsts.GRADLE_EXAMPLE_PUBLISH, buildResult -> {
             ValidationUtils.checkBuildResults(artifactoryManager, buildResult, localRepo);
             ValidationUtils.checkArtifactsProps(artifactoryManager);
         });
@@ -18,7 +18,7 @@ public class PluginPublishTest extends GradleFunctionalTestBase {
 
     @Test(dataProvider = "gradleVersions")
     public void publicationsTestKotlinDsl(String gradleVersion) throws IOException {
-        runPublishTest(gradleVersion, TestConstant.GRADLE_KTS_EXAMPLE_PUBLISH, buildResult -> {
+        runPublishTest(gradleVersion, TestConsts.GRADLE_KTS_EXAMPLE_PUBLISH, buildResult -> {
             ValidationUtils.checkBuildResults(artifactoryManager, buildResult, localRepo);
             ValidationUtils.checkArtifactsProps(artifactoryManager);
         });

--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/utils/Utils.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/utils/Utils.java
@@ -12,7 +12,7 @@ import org.jfrog.build.extractor.clientConfiguration.client.artifactory.Artifact
 import org.jfrog.build.extractor.clientConfiguration.client.response.GetAllBuildNumbersResponse;
 import org.jfrog.gradle.plugin.artifactory.Constant;
 import org.jfrog.gradle.plugin.artifactory.GradleFunctionalTestBase;
-import org.jfrog.gradle.plugin.artifactory.TestConstant;
+import org.jfrog.gradle.plugin.artifactory.TestConsts;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -36,7 +36,7 @@ public class Utils {
      * @param defaultValue - value if env var not exists
      */
     public static String readParam(String paramName, String defaultValue) {
-        String paramValue = System.getenv(TestConstant.BITESTS_ENV_VAR_PREFIX + paramName.toUpperCase());
+        String paramValue = System.getenv(TestConsts.BITESTS_ENV_VAR_PREFIX + paramName.toUpperCase());
         return StringUtils.defaultIfBlank(paramValue, defaultValue);
     }
 
@@ -47,7 +47,7 @@ public class Utils {
      * @throws IOException - In case of any IO error
      */
     public static void createTestDir(Path sourceDir) throws IOException {
-        FileUtils.copyDirectory(sourceDir.toFile(), TestConstant.TEST_DIR);
+        FileUtils.copyDirectory(sourceDir.toFile(), TestConsts.TEST_DIR);
     }
 
     /**
@@ -57,7 +57,7 @@ public class Utils {
      * @throws IOException - In case of any IO error
      */
     public static Path createDeployableArtifactsFile() throws IOException {
-        return Files.createFile(TestConstant.TEST_DIR.toPath().resolve("deployable.artifacts")).toAbsolutePath();
+        return Files.createFile(TestConsts.TEST_DIR.toPath().resolve("deployable.artifacts")).toAbsolutePath();
     }
 
     /**
@@ -83,7 +83,7 @@ public class Utils {
      * @throws IOException in case of any IO error
      */
     public static BuildResult runConfigurationCache(String gradleVersion, Map<String, String> envVars, boolean applyInitScript) throws IOException {
-        List<String> arguments = new ArrayList<>(List.of("--configuration-cache"));
+        List<String> arguments = new ArrayList<>(Collections.singletonList("--configuration-cache"));
         return runPluginTasks(gradleVersion, arguments, envVars, applyInitScript);
     }
 
@@ -100,12 +100,11 @@ public class Utils {
         if (applyInitScript) {
             generateInitScript();
             arguments.add("--init-script=gradle.init");
-//            arguments.add("-Dorg.gradle.jvmargs=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005");
         }
         //noinspection UnstableApiUsage
         return GradleRunner.create()
                 .withGradleVersion(gradleVersion)
-                .withProjectDir(TestConstant.TEST_DIR)
+                .withProjectDir(TestConsts.TEST_DIR)
                 .withPluginClasspath()
                 .withArguments(arguments)
                 .withEnvironment(envVars)
@@ -118,12 +117,12 @@ public class Utils {
      * @throws IOException - In case of any IO error
      */
     private static void generateInitScript() throws IOException {
-        String content = FileUtils.readFileToString(TestConstant.INIT_SCRIPT.toFile(), StandardCharsets.UTF_8);
+        String content = FileUtils.readFileToString(TestConsts.INIT_SCRIPT.toFile(), StandardCharsets.UTF_8);
         // Insert the path to lib (Escape "/" in Windows machines)
-        String libsDir = TestConstant.LIBS_DIR.toString().replaceAll("\\\\", "\\\\\\\\");
+        String libsDir = TestConsts.LIBS_DIR.toString().replaceAll("\\\\", "\\\\\\\\");
         content = content.replace("${pluginLibDir}", libsDir);
         // Write gradle.init file with the content
-        Path target = TestConstant.TEST_DIR.toPath().resolve("gradle.init");
+        Path target = TestConsts.TEST_DIR.toPath().resolve("gradle.init");
         Files.write(target, content.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -138,15 +137,15 @@ public class Utils {
      * @throws IOException - In case of any IO error
      */
     public static void generateBuildInfoProperties(GradleFunctionalTestBase testBase, String publications, boolean publishBuildInfo, boolean setDeployer, String deployableArtifacts) throws IOException {
-        String content = generateBuildInfoPropertiesForServer(testBase, publications, publishBuildInfo, TestConstant.BUILD_INFO_PROPERTIES_SOURCE_RESOLVER);
+        String content = generateBuildInfoPropertiesForServer(testBase, publications, publishBuildInfo, TestConsts.BUILD_INFO_PROPERTIES_SOURCE_RESOLVER);
         if (setDeployer) {
             content += "\n";
-            content += generateBuildInfoPropertiesForServer(testBase, publications, publishBuildInfo, TestConstant.BUILD_INFO_PROPERTIES_SOURCE_DEPLOYER);
+            content += generateBuildInfoPropertiesForServer(testBase, publications, publishBuildInfo, TestConsts.BUILD_INFO_PROPERTIES_SOURCE_DEPLOYER);
         }
         if (StringUtils.isNotBlank(deployableArtifacts)) {
             content += String.format("\n%s%s=%s", BUILD_INFO_PREFIX, DEPLOYABLE_ARTIFACTS, deployableArtifacts.replaceAll("\\\\", "\\\\\\\\"));
         }
-        Files.write(TestConstant.BUILD_INFO_PROPERTIES_TARGET, content.getBytes(StandardCharsets.UTF_8));
+        Files.write(TestConsts.BUILD_INFO_PROPERTIES_TARGET, content.getBytes(StandardCharsets.UTF_8));
     }
 
     /**
@@ -210,7 +209,7 @@ public class Utils {
                 .distinct()
 
                 // Match build number pattern.
-                .map(TestConstant.BUILD_NUMBER_PATTERN::matcher)
+                .map(TestConsts.BUILD_NUMBER_PATTERN::matcher)
                 .filter(Matcher::matches)
 
                 // Filter build numbers newer than 24 hours.

--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/utils/ValidationUtils.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/utils/ValidationUtils.java
@@ -12,7 +12,7 @@ import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.extractor.ci.Dependency;
 import org.jfrog.build.extractor.ci.Module;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
-import org.jfrog.gradle.plugin.artifactory.TestConstant;
+import org.jfrog.gradle.plugin.artifactory.TestConsts;
 import org.testng.collections.Sets;
 
 import java.io.File;
@@ -28,8 +28,8 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.jsonStringToBuildInfo;
 import static org.jfrog.build.extractor.clientConfiguration.deploy.DeployableArtifactsUtils.loadDeployableArtifactsFromFile;
 import static org.jfrog.gradle.plugin.artifactory.Constant.*;
-import static org.jfrog.gradle.plugin.artifactory.TestConstant.ARTIFACTS_GROUP_ID;
-import static org.jfrog.gradle.plugin.artifactory.TestConstant.EXPECTED_VERSION_CATALOG_CONSUMER_ARTIFACTS;
+import static org.jfrog.gradle.plugin.artifactory.TestConsts.ARTIFACTS_GROUP_ID;
+import static org.jfrog.gradle.plugin.artifactory.TestConsts.EXPECTED_VERSION_CATALOG_CONSUMER_ARTIFACTS;
 import static org.testng.Assert.*;
 import static org.testng.Assert.assertTrue;
 
@@ -51,7 +51,7 @@ public class ValidationUtils {
      * @throws IOException - In case of any IO error
      */
     public static void checkBuildResults(ArtifactoryManager artifactoryManager, BuildResult buildResult, String localRepo) throws IOException {
-        checkBuildResults(artifactoryManager, buildResult, localRepo, TestConstant.EXPECTED_MODULE_ARTIFACTS, 5);
+        checkBuildResults(artifactoryManager, buildResult, localRepo, TestConsts.EXPECTED_MODULE_ARTIFACTS, 5);
     }
 
     /**
@@ -65,7 +65,7 @@ public class ValidationUtils {
      */
     public static void checkBuildResults(ArtifactoryManager artifactoryManager, BuildResult buildResult, String localRepo, Path deployableArtifacts) throws IOException {
         checkBuildResults(artifactoryManager, buildResult, localRepo);
-        checkDeployableArtifacts(deployableArtifacts, Sets.newHashSet(TestConstant.EXPECTED_MODULE_ARTIFACTS), localRepo);
+        checkDeployableArtifacts(deployableArtifacts, Sets.newHashSet(TestConsts.EXPECTED_MODULE_ARTIFACTS), localRepo);
     }
 
     /**
@@ -103,7 +103,7 @@ public class ValidationUtils {
      * @throws IOException - In case of any IO error
      */
     public static void checkArchivesBuildResults(ArtifactoryManager artifactoryManager, BuildResult buildResult, String localRepo) throws IOException {
-        checkBuildResults(artifactoryManager, buildResult, localRepo, TestConstant.EXPECTED_ARCHIVE_ARTIFACTS, 1);
+        checkBuildResults(artifactoryManager, buildResult, localRepo, TestConsts.EXPECTED_ARCHIVE_ARTIFACTS, 1);
     }
 
     /**

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/listener/ProjectsEvaluatedBuildListener.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/listener/ProjectsEvaluatedBuildListener.java
@@ -1,11 +1,8 @@
 package org.jfrog.gradle.plugin.artifactory.listener;
 
 import org.apache.commons.lang3.StringUtils;
-import org.gradle.BuildAdapter;
 import org.gradle.StartParameter;
 import org.gradle.api.Project;
-import org.gradle.api.ProjectEvaluationListener;
-import org.gradle.api.ProjectState;
 import org.gradle.api.Task;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.Logger;
@@ -32,7 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * 3) Apply default action to projects
  * 4) Adding default attributes that are used in CI mode
  */
-public class ProjectsEvaluatedBuildListener extends BuildAdapter implements ProjectEvaluationListener {
+public class ProjectsEvaluatedBuildListener {
     private static final Logger log = Logging.getLogger(ProjectsEvaluatedBuildListener.class);
     private final Set<Task> detailsCollectingTasks = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
@@ -80,11 +77,8 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
      * If the configure-on-demand mode is active, Evaluates the ArtifactoryTask tasks
      *
      * @param project The project which was evaluated. Never null.
-     * @param state   The project evaluation state. If project evaluation failed, the exception is available in this
-     *                state. Never null.
      */
-    @Override
-    public void afterEvaluate(Project project, ProjectState state) {
+    public void afterEvaluate(Project project) {
         StartParameter startParameter = project.getGradle().getStartParameter();
         Set<Task> tasks = project.getTasksByName(Constant.ARTIFACTORY_PUBLISH_TASK_NAME, false);
         tasks.forEach(task -> {
@@ -106,7 +100,6 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
      *
      * @param gradle The build which has been evaluated. Never null.
      */
-    @Override
     public void projectsEvaluated(Gradle gradle) {
         Set<Task> tasks = gradle.getRootProject().getTasksByName(Constant.ARTIFACTORY_PUBLISH_TASK_NAME, false);
         detailsCollectingTasks.addAll(tasks);
@@ -117,9 +110,5 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
                 collectDeployDetailsTask.finalizeByDeployTask(collectDeployDetailsTask.getProject());
             }
         });
-    }
-
-    @Override
-    public void beforeEvaluate(Project project) {
     }
 }

--- a/src/main/resources/initscripttemplate.gradle
+++ b/src/main/resources/initscripttemplate.gradle
@@ -9,40 +9,33 @@ initscript {
     }
 }
 
-addListener(new BuildInfoPluginListener())
+beforeSettings { Settings settings ->
+    settings.apply plugin: ArtifactoryPluginSettings
+}
 
-class BuildInfoPluginListener extends BuildAdapter {
-
-    @Override
-    void beforeSettings(Settings settings) {
-        settings.apply plugin: ArtifactoryPluginSettings
-    }
-
-    @Override
-    void projectsLoaded(Gradle gradle) {
-        Map<String, String> projectProperties = new HashMap<String, String>(gradle.startParameter.getProjectProperties())
-        projectProperties.put("build.start", Long.toString(System.currentTimeMillis()))
-        gradle.startParameter.setProjectProperties(projectProperties)
-        Project root = gradle.getRootProject()
-        root.logger.debug("Artifactory plugin: projectsEvaluated: ${root.name}")
-        if (!"buildSrc".equals(root.name)) {
-            root.allprojects {
-                apply {
-                    apply plugin: ArtifactoryPlugin
-                }
+projectsLoaded { Gradle gradle ->
+    Map<String, String> projectProperties = new HashMap<String, String>(gradle.startParameter.getProjectProperties())
+    projectProperties.put("build.start", Long.toString(System.currentTimeMillis()))
+    gradle.startParameter.setProjectProperties(projectProperties)
+    Project root = gradle.getRootProject()
+    root.logger.debug("Artifactory plugin: projectsEvaluated: ${root.name}")
+    if (!"buildSrc".equals(root.name)) {
+        root.allprojects {
+            apply {
+                apply plugin: ArtifactoryPlugin
             }
         }
+    }
 
-        // Set the CI Server mode to all Artifactory tasks.
-        for (Project p : root.getAllprojects()) {
-            try {
-                TaskProvider<? extends Task> subCollectInfoTask = p.getTasks().named(Constant.ARTIFACTORY_PUBLISH_TASK_NAME, ArtifactoryTask.class);
-                subCollectInfoTask.configure { task ->
-                    task.setCiServerBuild()
-                }
-            } catch (UnknownTaskException e) {
-                root.logger.debug("Can't find sub project configured for {}", p.getPath());
+    // Set the CI Server mode to all Artifactory tasks.
+    for (Project p : root.getAllprojects()) {
+        try {
+            TaskProvider<? extends Task> subCollectInfoTask = p.getTasks().named(Constant.ARTIFACTORY_PUBLISH_TASK_NAME, ArtifactoryTask.class);
+            subCollectInfoTask.configure { task ->
+                task.setCiServerBuild()
             }
+        } catch (UnknownTaskException ignored) {
+            root.logger.debug("Can't find sub project configured for {}", p.getPath());
         }
     }
 }


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

To prevent the Gradle configuration cache from failing, exclude the call to addProjectEvaluationListener. This approach closely mirrors the solution implemented at https://github.com/jfrog/artifactory-gradle-plugin/pull/49.

Furthermore, this pull request introduces changes to the Gradle initialization script to eliminate the use of Gradle.addListener() within the init script.