### PR TITLE
Lower JDK compilation version to 8

### DIFF
--- a/.github/workflows/frogbot-scan-and-fix.yml
+++ b/.github/workflows/frogbot-scan-and-fix.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: "11"
-          distribution: "adopt"
+          java-version: "8"
+          distribution: "temurin"
 
       - uses: jfrog/frogbot@v2
         env:

--- a/.github/workflows/frogbot-scan-pull-request.yml
+++ b/.github/workflows/frogbot-scan-pull-request.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: "11"
+          java-version: "8"
           distribution: "temurin"
 
       - uses: jfrog/frogbot@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "8"
 
       - name: Setup Artifactory
         env:

--- a/.jfrog-pipelines/release/pipelines.release.yml
+++ b/.jfrog-pipelines/release/pipelines.release.yml
@@ -7,7 +7,7 @@ pipelines:
           auto:
             language: java
             versions:
-              - "11"
+              - "8"
       environmentVariables:
         readOnly:
           NEXT_VERSION: 0.0.0

--- a/.jfrog-pipelines/release/pipelines.snapshot.yml
+++ b/.jfrog-pipelines/release/pipelines.snapshot.yml
@@ -7,7 +7,7 @@ pipelines:
           auto:
             language: java
             versions:
-              - "11"
+              - "8"
     steps:
       - name: Snapshot
         type: Bash

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,12 +19,12 @@ val fileSpecsVersion = "1.1.2"
 val commonsLangVersion = "3.12.0"
 val commonsIoVersion = "2.11.0"
 val commonsTxtVersion = "1.10.0"
-val testNgVersion = "7.7.1"
+val testNgVersion = "7.5.1"
 val httpclientVersion = "4.5.14"
 
 tasks.compileJava {
-    sourceCompatibility = "11"
-    targetCompatibility = "11"
+    sourceCompatibility = "1.8"
+    targetCompatibility = "1.8"
 }
 
 java {

--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/GradleFunctionalTestBase.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/GradleFunctionalTestBase.java
@@ -100,7 +100,7 @@ public class GradleFunctionalTestBase {
         Utils.createTestDir(sourceDir);
         Path deployableArtifacts = createDeployableArtifactsFile();
         testEnvCreator.create(deployableArtifacts.toString());
-        Map<String, String> extendedEnv = new HashMap<>(envVars) {{
+        Map<String, String> extendedEnv = new HashMap<String, String>(envVars) {{
             put(BuildInfoConfigProperties.PROP_PROPS_FILE, TestConstant.BUILD_INFO_PROPERTIES_TARGET.toString());
             put(RESOLUTION_URL_ENV, getArtifactoryUrl() + virtualRepo);
             put(RESOLUTION_USERNAME_ENV, getUsername());
@@ -192,7 +192,7 @@ public class GradleFunctionalTestBase {
 
     private void initGradleCmdEnvVars() {
         // Create env vars to pass for running gradle commands (var replacement in build.gradle files?
-        envVars = new HashMap<>(System.getenv()) {{
+        envVars = new HashMap<String, String>(System.getenv()) {{
             putIfAbsent(TestConstant.BITESTS_ENV_VAR_PREFIX + TestConstant.URL, getPlatformUrl());
             putIfAbsent(TestConstant.BITESTS_ENV_VAR_PREFIX + TestConstant.USERNAME, getUsername());
             putIfAbsent(TestConstant.BITESTS_ENV_VAR_PREFIX + TestConstant.ADMIN_TOKEN, getAdminToken());

--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/utils/Utils.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/utils/Utils.java
@@ -105,7 +105,7 @@ public class Utils {
      * @throws IOException - In case of any IO error
      */
     private static void generateInitScript() throws IOException {
-        String content = Files.readString(TestConstant.INIT_SCRIPT);
+        String content = FileUtils.readFileToString(TestConstant.INIT_SCRIPT.toFile(), StandardCharsets.UTF_8);
         // Insert the path to lib (Escape "/" in Windows machines)
         String libsDir = TestConstant.LIBS_DIR.toString().replaceAll("\\\\", "\\\\\\\\");
         content = content.replace("${pluginLibDir}", libsDir);
@@ -147,8 +147,8 @@ public class Utils {
      * @throws IOException - In case of any IO error
      */
     private static String generateBuildInfoPropertiesForServer(GradleFunctionalTestBase testBase, String publications, boolean publishBuildInfo, Path source) throws IOException {
-        String content = Files.readString(source);
-        Map<String, String> valuesMap = new HashMap<>() {{
+        String content = FileUtils.readFileToString(source.toFile(), StandardCharsets.UTF_8);
+        Map<String, String> valuesMap = new HashMap<String, String>() {{
             put(ClientConfigurationFields.PUBLICATIONS, publications);
             put(ClientConfigurationFields.CONTEXT_URL, testBase.getArtifactoryUrl());
             put(ClientConfigurationFields.USERNAME, testBase.getUsername());


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

Lower the JDK compilation version to 8. This step is required to avoid encountering the following errors while attempting to utilize the plugin with the JFrog CLI:
> org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginSettings has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0