### PR TITLE
Enforce Gradle min version in the init script

### DIFF
--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginSettings.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginSettings.java
@@ -6,13 +6,11 @@ import org.gradle.api.credentials.PasswordCredentials;
 import org.gradle.api.initialization.Settings;
 
 import static org.jfrog.gradle.plugin.artifactory.Constant.*;
-import static org.jfrog.gradle.plugin.artifactory.utils.PluginUtils.assertGradleVersionSupported;
 
 @SuppressWarnings("unused")
 public class ArtifactoryPluginSettings implements Plugin<Settings> {
     @Override
     public void apply(Settings settings) {
-        assertGradleVersionSupported(settings.getGradle());
         String resolveContextUrl = System.getenv(RESOLUTION_URL_ENV);
         if (resolveContextUrl == null) {
             return;

--- a/src/main/resources/initscripttemplate.gradle
+++ b/src/main/resources/initscripttemplate.gradle
@@ -2,12 +2,15 @@ import org.jfrog.gradle.plugin.artifactory.ArtifactoryPlugin
 import org.jfrog.gradle.plugin.artifactory.ArtifactoryPluginSettings
 import org.jfrog.gradle.plugin.artifactory.Constant
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask
+import org.jfrog.gradle.plugin.artifactory.utils.PluginUtils;
 
 initscript {
     dependencies {
         classpath fileTree('${pluginLibDir}')
     }
 }
+
+PluginUtils.assertGradleVersionSupported(getGradle())
 
 beforeSettings { Settings settings ->
     settings.apply plugin: ArtifactoryPluginSettings


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

Trying to execute the plugin in CI mode using Gradle versions prior to 6 leads to an unhelpful error message as follows:
> A problem occurred evaluating initialization script.
> Could not find method beforeSettings() for arguments [init_artifactory94626938881760_15juxlr5otc52jxj9zoifqecd$_run_closure1@4b2a19be] on build of type org.gradle.invocation.DefaultGradle.

Following the implementation of this solution:
> A problem occurred evaluating initialization script.
> Can't apply Artifactory Plugin on Gradle version 5.6.3. Minimum supported Gradle version is 6.8.1