### PR TITLE
docs: wrong settings of publishBuildInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ configure<ArtifactoryPluginConvention> {
         }
 
         // (default: true) Publish the generated build-info file to Artifactory
-        publishBuildInfo(false)
+        publishBuildInfo = false
         // (default: 3) Number of threads that will work and deploy artifacts to Artifactory
         forkCount = 5
     }
@@ -290,7 +290,7 @@ artifactory {
         }
 
         // (default: true) Publish the generated build-info file to Artifactory
-        publishBuildInfo(false)
+        publishBuildInfo = false
         // (default: 3) Number of threads that will work and deploy artifacts to Artifactory
         forkCount = 5
     }


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

There seems to be an error in the usage of publishBuildInfo in the README.
We have confirmed that it works as expected when written to be passed as a variable value, not as a function.