### PR TITLE
afterEvaluate runs when project is already evaluated

### DIFF
--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/ArtifactoryPlugin.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/ArtifactoryPlugin.java
@@ -38,7 +38,9 @@ public class ArtifactoryPlugin implements Plugin<Project> {
                 // Add a DependencyResolutionListener, to populate the dependency hierarchy map
                 subproject.getConfigurations().all(config -> config.getIncoming().afterResolve(resolutionListener::afterResolve));
                 // Add after evaluation listener to evaluate the ArtifactoryPublish task
-                subproject.afterEvaluate((projectsEvaluatedBuildListener::afterEvaluate));
+                if (!subproject.getState().getExecuted()) {
+                    subproject.afterEvaluate((projectsEvaluatedBuildListener::afterEvaluate));
+                }
             });
             // Add after all projects evaluated listener to evaluate all the ArtifactoryTask tasks that are not yet evaluated
             project.getGradle().projectsEvaluated(projectsEvaluatedBuildListener::projectsEvaluated);


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

Fix the following issue:
```
An exception occurred applying plugin request [id: 'com.jfrog.artifactory']
> Failed to apply plugin class 'org.jfrog.gradle.plugin.artifactory.ArtifactoryPlugin'.
   > Cannot run Project.afterEvaluate(Action) when the project is already evaluated.
```

The problem occurs when the plugin is used but not applied in the root project:
```
 id 'com.jfrog.artifactory' version '5.1.6' apply false
```
