### PR TITLE
Migrate plugin conventions to extensions

### DIFF
--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/ArtifactoryPlugin.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/ArtifactoryPlugin.java
@@ -9,7 +9,7 @@ import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention;
 import org.jfrog.gradle.plugin.artifactory.listener.ArtifactoryDependencyResolutionListener;
 import org.jfrog.gradle.plugin.artifactory.listener.ProjectsEvaluatedBuildListener;
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask;
-import org.jfrog.gradle.plugin.artifactory.utils.ConventionUtils;
+import org.jfrog.gradle.plugin.artifactory.utils.ExtensionsUtils;
 import org.jfrog.gradle.plugin.artifactory.utils.ProjectUtils;
 import org.jfrog.gradle.plugin.artifactory.utils.TaskUtils;
 
@@ -25,8 +25,8 @@ public class ArtifactoryPlugin implements Plugin<Project> {
         if (!shouldApplyPluginOnProject(project)) {
             return;
         }
-        // Get / Add an Artifactory plugin convention to the project module
-        ArtifactoryPluginConvention convention = ConventionUtils.getOrCreateArtifactoryConvention(project);
+        // Get / Add an Artifactory plugin extension to the project module
+        ArtifactoryPluginConvention extension = ExtensionsUtils.getOrCreateArtifactoryExtension(project);
         // Add the collect publications for deploy details and extract module-info tasks to the project module
         TaskProvider<ArtifactoryTask> collectDeployDetailsTask = TaskUtils.addCollectDeployDetailsTask(project);
         TaskUtils.addExtractModuleInfoTask(collectDeployDetailsTask, project);
@@ -50,9 +50,9 @@ public class ArtifactoryPlugin implements Plugin<Project> {
         }
 
         // Set build started if not set
-        String buildStarted = convention.getClientConfig().info.getBuildStarted();
+        String buildStarted = extension.getClientConfig().info.getBuildStarted();
         if (buildStarted == null || buildStarted.isEmpty()) {
-            convention.getClientConfig().info.setBuildStarted(System.currentTimeMillis());
+            extension.getClientConfig().info.setBuildStarted(System.currentTimeMillis());
         }
 
         log.debug("Using Artifactory Plugin for " + project.getPath());

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/dsl/ArtifactoryPluginConvention.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/dsl/ArtifactoryPluginConvention.java
@@ -1,9 +1,7 @@
 package org.jfrog.gradle.plugin.artifactory.dsl;
 
-import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
-import org.gradle.util.ConfigureUtil;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 import org.jfrog.gradle.plugin.artifactory.utils.GradleClientLogger;
 
@@ -29,29 +27,17 @@ public class ArtifactoryPluginConvention {
         clientConfig.publisher.setContextUrl(contextUrl);
     }
 
-    public void publish(Closure<PublisherConfig> closure) {
-        publish(ConfigureUtil.configureUsing(closure));
-    }
-
     public void publish(Action<PublisherConfig> publishAction) {
-        publisherConfig = new PublisherConfig(this);
+        publisherConfig = project.getObjects().newInstance(PublisherConfig.class, project.getObjects(), this);
         publishAction.execute(publisherConfig);
     }
 
     @SuppressWarnings("unused")
-    public void buildInfo(Closure<ArtifactoryClientConfiguration.BuildInfoHandler> closure) {
-        buildInfo(ConfigureUtil.configureUsing(closure));
-    }
-
     public void buildInfo(Action<ArtifactoryClientConfiguration.BuildInfoHandler> buildInfoAction) {
         buildInfoAction.execute(clientConfig.info);
     }
 
     @SuppressWarnings("unused")
-    public void proxy(Closure<ArtifactoryClientConfiguration.ProxyHandler> closure) {
-        proxy(ConfigureUtil.configureUsing(closure));
-    }
-
     public void proxy(Action<ArtifactoryClientConfiguration.ProxyHandler> buildInfoAction) {
         buildInfoAction.execute(clientConfig.proxy);
     }

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/dsl/PublisherConfig.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/dsl/PublisherConfig.java
@@ -1,10 +1,11 @@
 package org.jfrog.gradle.plugin.artifactory.dsl;
 
-import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.util.ConfigureUtil;
+import org.gradle.api.model.ObjectFactory;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask;
+
+import javax.inject.Inject;
 
 /**
  * Main publish configuration object for the plugin. a DSL object that controls all the plugin publishing configurations.
@@ -18,9 +19,10 @@ public class PublisherConfig {
     // Configure global task that will be applied to all the projects
     Action<ArtifactoryTask> defaultsAction;
 
-    public PublisherConfig(ArtifactoryPluginConvention convention) {
-        this.publisher = convention.getClientConfig().publisher;
-        repository = new Repository(this.publisher);
+    @Inject
+    public PublisherConfig(ObjectFactory objectFactory, ArtifactoryPluginConvention extension) {
+        this.publisher = extension.getClientConfig().publisher;
+        repository = objectFactory.newInstance(Repository.class, publisher);
     }
 
     @SuppressWarnings("unused")
@@ -31,11 +33,6 @@ public class PublisherConfig {
     @SuppressWarnings("unused")
     public void setContextUrl(String contextUrl) {
         this.publisher.setContextUrl(contextUrl);
-    }
-
-    @SuppressWarnings("unused")
-    public void defaults(Closure<ArtifactoryTask> closure) {
-        defaults(ConfigureUtil.configureUsing(closure));
     }
 
     public void defaults(Action<ArtifactoryTask> defaultsAction) {
@@ -67,9 +64,9 @@ public class PublisherConfig {
     }
 
     @SuppressWarnings("unused")
-    public void repository(Closure<Repository> closure) { repository(ConfigureUtil.configureUsing(closure)); }
-
-    public void repository(Action<Repository> repositoryAction) { repositoryAction.execute(repository); }
+    public void repository(Action<Repository> repositoryAction) {
+        repositoryAction.execute(repository);
+    }
 
     @SuppressWarnings("unused")
     public Repository getRepository() {
@@ -80,6 +77,7 @@ public class PublisherConfig {
         private final ArtifactoryClientConfiguration.PublisherHandler publisher;
         private final IvyPublishInfo ivyPublishInfo;
 
+        @Inject
         public Repository(ArtifactoryClientConfiguration.PublisherHandler publisher) {
             this.publisher = publisher;
             this.ivyPublishInfo = new IvyPublishInfo(publisher);
@@ -112,10 +110,6 @@ public class PublisherConfig {
         }
 
         @SuppressWarnings("unused")
-        public void ivy(Closure<IvyPublishInfo> closure) {
-            ivy(ConfigureUtil.configureUsing(closure));
-        }
-
         public void ivy(Action<IvyPublishInfo> ivyAction) {
             ivyAction.execute(ivyPublishInfo);
         }
@@ -128,6 +122,7 @@ public class PublisherConfig {
 
     public static class IvyPublishInfo {
         private final ArtifactoryClientConfiguration.PublisherHandler publisher;
+
         public IvyPublishInfo(ArtifactoryClientConfiguration.PublisherHandler publisher) {
             this.publisher = publisher;
         }

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/GradleModuleExtractor.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/GradleModuleExtractor.java
@@ -26,7 +26,7 @@ import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
 import org.jfrog.gradle.plugin.artifactory.ArtifactoryPlugin;
 import org.jfrog.gradle.plugin.artifactory.listener.ArtifactoryDependencyResolutionListener;
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask;
-import org.jfrog.gradle.plugin.artifactory.utils.ConventionUtils;
+import org.jfrog.gradle.plugin.artifactory.utils.ExtensionsUtils;
 import org.jfrog.gradle.plugin.artifactory.utils.ProjectUtils;
 import org.jfrog.gradle.plugin.artifactory.utils.TaskUtils;
 
@@ -86,7 +86,7 @@ public class GradleModuleExtractor implements ModuleExtractor<Project> {
             // Extract the module's dependencies
             builder.dependencies(calculateDependencies(project, moduleId));
             // Extract the module's artifacts
-            ArtifactoryClientConfiguration.PublisherHandler publisher = ConventionUtils.getPublisherHandler(project);
+            ArtifactoryClientConfiguration.PublisherHandler publisher = ExtensionsUtils.getPublisherHandler(project);
             if (publisher == null) {
                 log.warn("No publisher config found for project: " + project.getName());
                 return builder;

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/listener/ProjectsEvaluatedBuildListener.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/listener/ProjectsEvaluatedBuildListener.java
@@ -12,7 +12,7 @@ import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfigurat
 import org.jfrog.gradle.plugin.artifactory.Constant;
 import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention;
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask;
-import org.jfrog.gradle.plugin.artifactory.utils.ConventionUtils;
+import org.jfrog.gradle.plugin.artifactory.utils.ExtensionsUtils;
 import org.jfrog.gradle.plugin.artifactory.utils.ProjectUtils;
 import org.jfrog.gradle.plugin.artifactory.utils.PublicationUtils;
 
@@ -39,18 +39,18 @@ public class ProjectsEvaluatedBuildListener {
     private void evaluate(ArtifactoryTask collectDeployDetailsTask) {
         log.debug("Try to evaluate {}", collectDeployDetailsTask);
         Project project = collectDeployDetailsTask.getProject();
-        ArtifactoryPluginConvention convention = ConventionUtils.getArtifactoryConvention(project);
-        if (convention == null) {
-            log.debug("Can't find artifactory convention.");
+        ArtifactoryPluginConvention extension = ExtensionsUtils.getArtifactoryExtension(project);
+        if (extension == null) {
+            log.debug("Can't find artifactory extension.");
             return;
         }
-        ArtifactoryClientConfiguration clientConfiguration = convention.getClientConfig();
+        ArtifactoryClientConfiguration clientConfiguration = extension.getClientConfig();
         if (clientConfiguration == null) {
             log.debug("Client configuration not defined.");
             return;
         }
         // Fill-in the client config with current user/system properties for the given project
-        ConventionUtils.updateConfig(clientConfiguration, project);
+        ExtensionsUtils.updateConfig(clientConfiguration, project);
         // Set task attributes if running on CI Server
         if (collectDeployDetailsTask.isCiServerBuild()) {
             addCiAttributesToTask(collectDeployDetailsTask, clientConfiguration);

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
@@ -2,7 +2,6 @@ package org.jfrog.gradle.plugin.artifactory.task;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import groovy.lang.Closure;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.*;
 import org.gradle.api.artifacts.Configuration;
@@ -20,7 +19,6 @@ import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.internal.publication.MavenPublicationInternal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.*;
-import org.gradle.util.ConfigureUtil;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactSpecs;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 import org.jfrog.gradle.plugin.artifactory.Constant;
@@ -28,7 +26,7 @@ import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention;
 import org.jfrog.gradle.plugin.artifactory.dsl.PropertiesConfig;
 import org.jfrog.gradle.plugin.artifactory.dsl.PublisherConfig;
 import org.jfrog.gradle.plugin.artifactory.extractor.GradleDeployDetails;
-import org.jfrog.gradle.plugin.artifactory.utils.ConventionUtils;
+import org.jfrog.gradle.plugin.artifactory.utils.ExtensionsUtils;
 import org.jfrog.gradle.plugin.artifactory.utils.PublicationUtils;
 
 import javax.annotation.Nullable;
@@ -95,16 +93,16 @@ public class ArtifactoryTask extends DefaultTask {
             }
         }
 
-        ArtifactoryPluginConvention convention = ConventionUtils.getConventionWithPublisher(project);
-        if (convention == null) {
-            log.debug("Can't find convention configured for {}", getPath());
+        ArtifactoryPluginConvention extension = ExtensionsUtils.getExtensionWithPublisher(project);
+        if (extension == null) {
+            log.debug("Can't find extension configured for {}", getPath());
             return;
         }
         // Add global properties to the specs
         artifactSpecs.clear();
-        artifactSpecs.addAll(convention.getClientConfig().publisher.getArtifactSpecs());
+        artifactSpecs.addAll(extension.getClientConfig().publisher.getArtifactSpecs());
         // Configure the task using the "defaults" action if exists (delegate to the task)
-        PublisherConfig config = convention.getPublisherConfig();
+        PublisherConfig config = extension.getPublisherConfig();
         if (config != null) {
             Action<ArtifactoryTask> defaultsAction = config.getDefaultsAction();
             if (defaultsAction != null) {
@@ -159,7 +157,7 @@ public class ArtifactoryTask extends DefaultTask {
     }
 
     private void collectDetailsFromConfigurations() {
-        ArtifactoryClientConfiguration.PublisherHandler publisher = ConventionUtils.getPublisherHandler(getProject());
+        ArtifactoryClientConfiguration.PublisherHandler publisher = ExtensionsUtils.getPublisherHandler(getProject());
         if (publisher == null) {
             return;
         }
@@ -366,10 +364,6 @@ public class ArtifactoryTask extends DefaultTask {
         }
     }
 
-    public void properties(Closure<PropertiesConfig> closure) {
-        properties(ConfigureUtil.configureUsing(closure));
-    }
-
     public void properties(Action<PropertiesConfig> propertiesAction) {
         PropertiesConfig propertiesConfig = new PropertiesConfig(getProject());
         propertiesAction.execute(propertiesConfig);
@@ -436,7 +430,7 @@ public class ArtifactoryTask extends DefaultTask {
             defaultProps = new HashMap<>();
             PublicationUtils.addProps(defaultProps, getProperties());
             // Add the publisher properties
-            ArtifactoryClientConfiguration.PublisherHandler publisher = ConventionUtils.getPublisherHandler(getProject().getRootProject());
+            ArtifactoryClientConfiguration.PublisherHandler publisher = ExtensionsUtils.getPublisherHandler(getProject().getRootProject());
             if (publisher != null) {
                 defaultProps.putAll(publisher.getMatrixParams());
             }

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
@@ -17,7 +17,7 @@ import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
 import org.jfrog.gradle.plugin.artifactory.extractor.GradleBuildInfoExtractor;
 import org.jfrog.gradle.plugin.artifactory.extractor.ModuleInfoFileProducer;
 import org.jfrog.gradle.plugin.artifactory.Constant;
-import org.jfrog.gradle.plugin.artifactory.utils.ConventionUtils;
+import org.jfrog.gradle.plugin.artifactory.utils.ExtensionsUtils;
 import org.jfrog.gradle.plugin.artifactory.utils.DeployUtils;
 import org.jfrog.gradle.plugin.artifactory.utils.TaskUtils;
 
@@ -51,7 +51,7 @@ public class DeployTask extends DefaultTask {
     @TaskAction
     public void extractBuildInfoAndDeploy() throws IOException {
         log.debug("Extracting build-info and deploying build details in task '{}'", getPath());
-        ArtifactoryClientConfiguration accRoot = ConventionUtils.getArtifactoryConvention(getProject()).getClientConfig();
+        ArtifactoryClientConfiguration accRoot = ExtensionsUtils.getArtifactoryExtension(getProject()).getClientConfig();
         // Deploy Artifacts to artifactory
         Map<String, Set<DeployDetails>> allDeployedDetails = deployArtifactsFromTasks(accRoot);
         // Generate build-info and handle deployment (and artifact exports if configured)

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/DeployUtils.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/DeployUtils.java
@@ -47,7 +47,7 @@ public class DeployUtils {
                 log.debug("Task '{}' has nothing to deploy", artifactoryTask.getPath());
                 return;
             }
-            ArtifactoryClientConfiguration.PublisherHandler taskPublisher = ConventionUtils.getPublisherHandler(artifactoryTask.getProject());
+            ArtifactoryClientConfiguration.PublisherHandler taskPublisher = ExtensionsUtils.getPublisherHandler(artifactoryTask.getProject());
             if (taskPublisher == null) {
                 log.debug("Task '{}' does not have publisher configured", artifactoryTask.getPath());
                 return;

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/ExtensionsUtils.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/ExtensionsUtils.java
@@ -16,43 +16,42 @@ import java.util.Set;
 
 import static org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration.addDefaultPublisherAttributes;
 
-public class ConventionUtils {
+public class ExtensionsUtils {
 
     /**
-     * Get or create if not exists an artifactory convention for a given project
+     * Get or create if not exists an artifactory extension for a given project
      *
-     * @param project - the project to fetch/create its convention
-     * @return project convention
+     * @param project - the project to fetch/create its extension
+     * @return project extension
      */
-    public static ArtifactoryPluginConvention getOrCreateArtifactoryConvention(Project project) {
-        ArtifactoryPluginConvention con = project.getConvention().findPlugin(ArtifactoryPluginConvention.class);
+    public static ArtifactoryPluginConvention getOrCreateArtifactoryExtension(Project project) {
+        ArtifactoryPluginConvention con = project.getExtensions().findByType(ArtifactoryPluginConvention.class);
         if (con == null) {
             con = project.getExtensions().create(Constant.ARTIFACTORY, ArtifactoryPluginConvention.class, project);
-            project.getConvention().getPlugins().put(Constant.ARTIFACTORY, con);
         }
         return con;
     }
 
     /**
-     * Get the Artifactory convention that is defined at the root project of a given project
+     * Get the Artifactory extension that is defined at the root project of a given project
      *
-     * @param project - the project that will get its root's convention
-     * @return Artifactory's convention defined at the root project if exists
+     * @param project - the project that will get its root's extension
+     * @return Artifactory's extension defined at the root project if exists
      */
-    public static ArtifactoryPluginConvention getArtifactoryConvention(Project project) {
-        return project.getRootProject().getConvention().findPlugin(ArtifactoryPluginConvention.class);
+    public static ArtifactoryPluginConvention getArtifactoryExtension(Project project) {
+        return project.getRootProject().getExtensions().findByType(ArtifactoryPluginConvention.class);
     }
 
     /**
-     * Get a convention of a given project that configured a publisher with: contextUrl and repoKey/snapshotRepoKey
+     * Get an extension of a given project that configured a publisher with: contextUrl and repoKey/snapshotRepoKey
      * If the current project didn't configure a publisher tries the parent until one is found
      *
      * @param project - the project to fetch its publisher configurations
-     * @return an Artifactory convention with publisher configured or null if not found
+     * @return an Artifactory extension with publisher configured or null if not found
      */
-    public static ArtifactoryPluginConvention getConventionWithPublisher(Project project) {
+    public static ArtifactoryPluginConvention getExtensionWithPublisher(Project project) {
         while (project != null) {
-            ArtifactoryPluginConvention acc = project.getConvention().findPlugin(ArtifactoryPluginConvention.class);
+            ArtifactoryPluginConvention acc = project.getExtensions().findByType(ArtifactoryPluginConvention.class);
             if (acc != null) {
                 ArtifactoryClientConfiguration.PublisherHandler publisher = acc.getClientConfig().publisher;
                 if (publisher.getContextUrl() != null && (publisher.getRepoKey() != null || publisher.getSnapshotRepoKey() != null)) {
@@ -71,11 +70,11 @@ public class ConventionUtils {
      * @return a configured publisher handler or null if not found
      */
     public static ArtifactoryClientConfiguration.PublisherHandler getPublisherHandler(Project project) {
-        ArtifactoryPluginConvention convention = getConventionWithPublisher(project);
-        if (convention == null) {
+        ArtifactoryPluginConvention extension = getExtensionWithPublisher(project);
+        if (extension == null) {
             return null;
         }
-        return convention.getClientConfig().publisher;
+        return extension.getClientConfig().publisher;
     }
 
     /**
@@ -86,7 +85,7 @@ public class ConventionUtils {
      * 4) default publisher attributes
      *
      * @param configuration - configuration to update
-     * @param project - project to get parent information and start parameters
+     * @param project       - project to get parent information and start parameters
      */
     public static void updateConfig(ArtifactoryClientConfiguration configuration, Project project) {
         Properties props = new Properties();

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/PublicationUtils.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/PublicationUtils.java
@@ -172,7 +172,7 @@ public class PublicationUtils {
      * Checks global publisher config if exists, if not exists checks specific task configuration
      */
     private static boolean isPublishIvy(ArtifactoryTask task) {
-        ArtifactoryClientConfiguration.PublisherHandler publisher = ConventionUtils.getPublisherHandler(task.getProject());
+        ArtifactoryClientConfiguration.PublisherHandler publisher = ExtensionsUtils.getPublisherHandler(task.getProject());
         if (publisher == null) {
             return false;
         }
@@ -215,7 +215,7 @@ public class PublicationUtils {
     private static void addIvyArtifactToDeployDetails(ArtifactoryTask destination, String publicationName,
                                                       IvyPublicationIdentity projectIdentity, DeployDetails.Builder builder,
                                                       PublishArtifactInfo artifactInfo) {
-        ArtifactoryClientConfiguration.PublisherHandler publisher = ConventionUtils.getPublisherHandler(destination.getProject());
+        ArtifactoryClientConfiguration.PublisherHandler publisher = ExtensionsUtils.getPublisherHandler(destination.getProject());
         if (publisher == null) {
             return;
         }
@@ -316,7 +316,7 @@ public class PublicationUtils {
      * Checks global publisher config if exists, if not exists checks specific task configuration
      */
     private static boolean isPublishMaven(ArtifactoryTask task) {
-        ArtifactoryClientConfiguration.PublisherHandler publisher = ConventionUtils.getPublisherHandler(task.getProject());
+        ArtifactoryClientConfiguration.PublisherHandler publisher = ExtensionsUtils.getPublisherHandler(task.getProject());
         if (publisher == null) {
             return false;
         }
@@ -388,7 +388,7 @@ public class PublicationUtils {
     private static void addArtifactInfoToDeployDetails(ArtifactoryTask destination, String publicationName,
                                                        DeployDetails.Builder builder, PublishArtifactInfo artifactInfo, String artifactPath) {
         Project project = destination.getProject();
-        ArtifactoryClientConfiguration.PublisherHandler publisher = ConventionUtils.getPublisherHandler(project);
+        ArtifactoryClientConfiguration.PublisherHandler publisher = ExtensionsUtils.getPublisherHandler(project);
         if (publisher != null) {
             builder.targetRepository(getTargetRepository(artifactPath, publisher));
             Map<String, String> propsToAdd = getPropsToAdd(destination, artifactInfo, publicationName);


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

Fix https://github.com/jfrog/artifactory-gradle-plugin/issues/43
Supersedes https://github.com/jfrog/artifactory-gradle-plugin/pull/62

The notion of Gradle conventions has been deprecated. 
In essence, this pull request is intended migrate of the plugin to the extensions concept by eliminating all occurrences of ConfigureUtil.configureUsing(Closure closure) and replacing them with ObjectFactory.newInstance(Class, Object...). It also replaces all references to ConventionUtils with ExtensionsUtils.

As per the information provided in the [ConfigureUtil](https://docs.gradle.org/current/javadoc/org/gradle/util/ConfigureUtil.html) documentation:
> Gradle automatically generates a Closure-taking method at runtime for each method with an [Action](https://docs.gradle.org/current/javadoc/org/gradle/api/Action.html) as a single argument as long as the object is created with [ObjectFactory.newInstance(Class, Object...)](https://docs.gradle.org/current/javadoc/org/gradle/api/model/ObjectFactory.html#newInstance-java.lang.Class-java.lang.Object...-).

To utilize ObjectFactory.newInstance, a constructor must have the `@Inject` annotation applied.