### PR TITLE
CI - Prefer repo from settings over project

### DIFF
--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/GradleFunctionalTestBase.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/GradleFunctionalTestBase.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
-import static org.jfrog.gradle.plugin.artifactory.Constant.*;
 import static org.jfrog.gradle.plugin.artifactory.TestConsts.MIN_GRADLE_VERSION_CONFIG_CACHE;
 import static org.jfrog.gradle.plugin.artifactory.utils.Utils.createDeployableArtifactsFile;
 import static org.testng.Assert.assertEquals;
@@ -45,6 +44,7 @@ public class GradleFunctionalTestBase {
     public final String localRepo = getKeyWithTimestamp(TestConsts.GRADLE_LOCAL_REPO);
     public final String virtualRepo = getKeyWithTimestamp(TestConsts.GRADLE_VIRTUAL_REPO);
     protected String remoteRepo = getKeyWithTimestamp(TestConsts.GRADLE_REMOTE_REPO);
+    protected String remoteGoogleRepo = getKeyWithTimestamp(TestConsts.GRADLE_REMOTE_GOOGLE_REPO);
 
     // Test specific attributes
     private StringSubstitutor stringSubstitutor;
@@ -78,6 +78,9 @@ public class GradleFunctionalTestBase {
         }
         if (StringUtils.isNotEmpty(remoteRepo)) {
             deleteTestRepo(remoteRepo);
+        }
+        if (StringUtils.isNotEmpty(remoteGoogleRepo)) {
+            deleteTestRepo(remoteGoogleRepo);
         }
         if (StringUtils.isNotEmpty(localRepo)) {
             deleteTestRepo(localRepo);
@@ -171,6 +174,9 @@ public class GradleFunctionalTestBase {
         if (StringUtils.isNotEmpty(remoteRepo)) {
             createTestRepo(remoteRepo);
         }
+        if (StringUtils.isNotEmpty(remoteGoogleRepo)) {
+            createTestRepo(remoteGoogleRepo);
+        }
         if (StringUtils.isNotEmpty(virtualRepo)) {
             createTestRepo(virtualRepo);
         }
@@ -180,6 +186,7 @@ public class GradleFunctionalTestBase {
         Map<String, Object> textParameters = new HashMap<>();
         textParameters.put(TestConsts.LOCAL_REPO, localRepo);
         textParameters.put(TestConsts.REMOTE_REPO, remoteRepo);
+        textParameters.put(TestConsts.REMOTE_GOOGLE_REPO, remoteGoogleRepo);
         stringSubstitutor = new StringSubstitutor(textParameters);
     }
 

--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/TestConsts.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/TestConsts.java
@@ -36,9 +36,11 @@ public class TestConsts {
     // Repositories
     public static final String LOCAL_REPO = "LOCAL_REPO";
     public static final String REMOTE_REPO = "REMOTE_REPO";
+    public static final String REMOTE_GOOGLE_REPO = "REMOTE_GOOGLE_REPO";
     public static final String VIRTUAL_REPO = "VIRTUAL_REPO";
     public static final String GRADLE_LOCAL_REPO = "build-info-tests-gradle-local";
     public static final String GRADLE_REMOTE_REPO = "build-info-tests-gradle-remote";
+    public static final String GRADLE_REMOTE_GOOGLE_REPO = "build-info-tests-gradle-remote-google";
     public static final String GRADLE_VIRTUAL_REPO = "build-info-tests-gradle-virtual";
 
     // Env vars

--- a/src/functionalTest/resources/gradle-android-ci-example/build.gradle
+++ b/src/functionalTest/resources/gradle-android-ci-example/build.gradle
@@ -3,13 +3,11 @@ allprojects {
     version = currentVersion
     repositories {
         maven {
-            url "${System.env.BITESTS_PLATFORM_URL}/artifactory/${System.env.BITESTS_ARTIFACTORY_VIRTUAL_REPO}"
+            url "should-override-me"
             credentials {
-                username "${System.env.BITESTS_PLATFORM_USERNAME}"
-                password "${System.env.BITESTS_PLATFORM_ADMIN_TOKEN}"
+                password "should-override-me"
             }
         }
-        google()
     }
 }
 

--- a/src/functionalTest/resources/gradle-example-ci-server-archives/build.gradle
+++ b/src/functionalTest/resources/gradle-example-ci-server-archives/build.gradle
@@ -1,32 +1,31 @@
 def javaProjects() {
-  subprojects.findAll { new File(it.projectDir, 'src').directory }
+    subprojects.findAll { new File(it.projectDir, 'src').directory }
 }
 
 allprojects {
-  group = 'org.jfrog.test.gradle.publish'
-  version = currentVersion
-  status = 'Integration'
-  repositories {
-    maven {
-      url "${System.env.BITESTS_PLATFORM_URL}/artifactory/${System.env.BITESTS_ARTIFACTORY_VIRTUAL_REPO}"
-      credentials {
-        username "${System.env.BITESTS_PLATFORM_USERNAME}"
-        password "${System.env.BITESTS_PLATFORM_ADMIN_TOKEN}"
-      }
+    group = 'org.jfrog.test.gradle.publish'
+    version = currentVersion
+    status = 'Integration'
+    repositories {
+        maven {
+            url "should-override-me"
+            credentials {
+                username "should-override-me"
+            }
+        }
     }
-  }
 }
 
 artifactoryPublish.skip = true
 
 project('services') {
-  artifactoryPublish.skip = true
+    artifactoryPublish.skip = true
 }
 
 configure(javaProjects()) {
-  apply plugin: 'java'
+    apply plugin: 'java'
 
-  dependencies {
-    testImplementation 'junit:junit:4.7'
-  }
+    dependencies {
+        testImplementation 'junit:junit:4.7'
+    }
 }

--- a/src/functionalTest/resources/gradle-example-ci-server/build.gradle
+++ b/src/functionalTest/resources/gradle-example-ci-server/build.gradle
@@ -1,46 +1,45 @@
 def javaProjects() {
-  subprojects.findAll { new File(it.projectDir, 'src').directory }
+    subprojects.findAll { new File(it.projectDir, 'src').directory }
 }
 
 allprojects {
-  group = 'org.jfrog.test.gradle.publish'
-  version = currentVersion
-  status = 'Integration'
-  repositories {
-    maven {
-      url "${System.env.BITESTS_PLATFORM_URL}/artifactory/${System.env.BITESTS_ARTIFACTORY_VIRTUAL_REPO}"
-      credentials {
-        username "${System.env.BITESTS_PLATFORM_USERNAME}"
-        password "${System.env.BITESTS_PLATFORM_ADMIN_TOKEN}"
-      }
+    group = 'org.jfrog.test.gradle.publish'
+    version = currentVersion
+    status = 'Integration'
+    repositories {
+        maven {
+            url "should-override-me"
+            credentials {
+                password "should-override-me"
+            }
+        }
     }
-  }
 }
 
 artifactoryPublish.skip = true
 
 project('services') {
-  artifactoryPublish.skip = true
+    artifactoryPublish.skip = true
 }
 
 configure(javaProjects()) {
-  apply plugin: 'java'
-  apply plugin: 'maven-publish'
-  apply plugin: 'ivy-publish'
+    apply plugin: 'java'
+    apply plugin: 'maven-publish'
+    apply plugin: 'ivy-publish'
 
-  dependencies {
-    testImplementation 'junit:junit:4.7'
-  }
-
-  publishing {
-    publications {
-      mavenJava(MavenPublication) {
-        from components.java
-        artifact(file("$rootDir/gradle.properties"))
-      }
-      customIvyPublication(IvyPublication) {
-        from components.java
-      }
+    dependencies {
+        testImplementation 'junit:junit:4.7'
     }
-  }
+
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                from components.java
+                artifact(file("$rootDir/gradle.properties"))
+            }
+            customIvyPublication(IvyPublication) {
+                from components.java
+            }
+        }
+    }
 }

--- a/src/functionalTest/resources/settings/build-info-tests-gradle-remote-google.json
+++ b/src/functionalTest/resources/settings/build-info-tests-gradle-remote-google.json
@@ -1,0 +1,6 @@
+{
+  "packageType": "gradle",
+  "repoLayoutRef": "maven-2-default",
+  "url": "https://maven.google.com",
+  "rclass": "remote"
+}

--- a/src/functionalTest/resources/settings/build-info-tests-gradle-virtual.json
+++ b/src/functionalTest/resources/settings/build-info-tests-gradle-virtual.json
@@ -3,7 +3,8 @@
   "packageType": "gradle",
   "repositories": [
     "${LOCAL_REPO}",
-    "${REMOTE_REPO}"
+    "${REMOTE_REPO}",
+    "${REMOTE_GOOGLE_REPO}"
   ],
   "defaultDeploymentRepo": "${LOCAL_REPO}"
 }

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginSettings.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginSettings.java
@@ -3,6 +3,7 @@ package org.jfrog.gradle.plugin.artifactory;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Plugin;
 import org.gradle.api.initialization.Settings;
+import org.gradle.api.initialization.resolve.RepositoriesMode;
 import org.gradle.api.logging.Logging;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.BuildInfoExtractorUtils;
@@ -23,6 +24,7 @@ public class ArtifactoryPluginSettings implements Plugin<Settings> {
             return;
         }
         String contextUrl = StringUtils.appendIfMissing(resolver.getContextUrl(), "/");
+        settings.getDependencyResolutionManagement().getRepositoriesMode().set(RepositoriesMode.PREFER_SETTINGS);
         settings.getDependencyResolutionManagement().getRepositories().maven(mavenArtifactRepository -> {
             mavenArtifactRepository.setName("artifactoryResolutionRepository");
             mavenArtifactRepository.setUrl(contextUrl + resolver.getRepoKey());


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

In CI mode, when a resolution server is specified, the plugin should prioritize repository settings configured by the user in the JFrog CLI / Jenkins Artifactory plugin over those in the `build.gradle` file. For example, configuring the Gradle project with `jf gradlec --server-id-resolve maven-remote` and executing `jf gradle clean aP` should result in the use of the maven-remote repository instead of any repositories mentioned in the `build.gradle` file.