### PR TITLE
Add missing JavaDoc params to fix compilation warnings

### DIFF
--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/PublicationUtils.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/PublicationUtils.java
@@ -154,6 +154,12 @@ public class PublicationUtils {
 
     /**
      * Adds a general artifact to deploy details in the given task destination
+     *
+     * @param destination     - Task to collect and store the created details
+     * @param publicationName - The publication name that published this artifact
+     * @param builder         - Deploy details builder
+     * @param artifactInfo    - The artifact info
+     * @param artifactPath    - The full path string to deploy the artifact
      */
     public static void addArtifactInfoToDeployDetails(ArtifactoryTask destination, String publicationName,
                                                       DeployDetails.Builder builder, PublishArtifactInfo artifactInfo, String artifactPath) {


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md) passed. If this feature is not already covered by the tests, I added new
  tests.

-----
