### PR TITLE
Allow setting the module type of the published module

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,9 @@ tasks.named<ArtifactoryTask>("artifactoryPublish") {
     setPublishPom(false)
     // (default: true) Publish generated Ivy descriptor files to Artifactory, can be specified as boolean/string
     setPublishIvy(false)
+    // (default: 'GRADLE') Set a custom module type for the published module in the build-info. 
+    // Acceptable values: 'GENERIC', 'MAVEN', 'GRADLE', 'IVY', 'DOCKER', 'NUGET', 'NPM', 'GO', 'PYPI', 'CPP'
+    setModuleType("GRADLE")
 }
 ```
 
@@ -404,6 +407,7 @@ artifactoryPublish {
     publishArtifacts = false
     publishPom = false
     publishIvy = false
+    moduleType = 'GRADLE'
 }
 ```
 

--- a/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/GradlePluginPublishTest.java
+++ b/src/functionalTest/java/org/jfrog/gradle/plugin/artifactory/tests/GradlePluginPublishTest.java
@@ -1,6 +1,7 @@
 package org.jfrog.gradle.plugin.artifactory.tests;
 
 import org.gradle.testkit.runner.BuildResult;
+import org.jfrog.build.api.builder.ModuleType;
 import org.jfrog.build.api.dependency.PropertySearchResult;
 import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.extractor.ci.Module;
@@ -59,5 +60,6 @@ public class GradlePluginPublishTest extends GradleFunctionalTestBase {
         assertNotNull(module);
         assertEquals(module.getArtifacts().size(), 4);
         assertEquals(module.getDependencies().size(), 1);
+        assertEquals(module.getType().toUpperCase(), ModuleType.GENERIC.toString());
     }
 }

--- a/src/functionalTest/resources/gradle-example-publish/build.gradle
+++ b/src/functionalTest/resources/gradle-example-publish/build.gradle
@@ -26,6 +26,7 @@ artifactoryPublish.skip = true
 
 project('services') {
     artifactoryPublish.skip = true
+    artifactoryPublish.moduleType = "GRADLE"
 }
 
 configure(javaProjects()) {
@@ -53,7 +54,7 @@ artifactory {
     clientConfig.info.addEnvironmentProperty('test.adding.dynVar', new java.util.Date().toString())
 
     publish {
-        contextUrl = "$System.env.BITESTS_PLATFORM_URL"+"/artifactory"
+        contextUrl = "$System.env.BITESTS_PLATFORM_URL" + "/artifactory"
         repository {
             repoKey = "$System.env.BITESTS_ARTIFACTORY_LOCAL_REPO" // The Artifactory repository key to publish to
             username = "$System.env.BITESTS_PLATFORM_USERNAME" // The publisher user name

--- a/src/functionalTest/resources/gradle-kts-example-publish/build.gradle.kts
+++ b/src/functionalTest/resources/gradle-kts-example-publish/build.gradle.kts
@@ -31,6 +31,7 @@ allprojects {
 tasks {
     named<ArtifactoryTask>("artifactoryPublish") {
         skip = true
+        setModuleType("GRADLE")
     }
 }
 
@@ -38,6 +39,7 @@ project("services") {
     tasks {
         named<ArtifactoryTask>("artifactoryPublish") {
             skip = true
+            moduleType = "GRADLE"
         }
     }
 }
@@ -67,7 +69,7 @@ configure<ArtifactoryPluginConvention> {
     clientConfig.info.addEnvironmentProperty("test.adding.dynVar", java.util.Date().toString())
 
     publish {
-        setContextUrl(System.getenv("BITESTS_PLATFORM_URL")+"/artifactory")
+        setContextUrl(System.getenv("BITESTS_PLATFORM_URL") + "/artifactory")
         repository {
             setRepoKey(System.getenv("BITESTS_ARTIFACTORY_LOCAL_REPO")) // The Artifactory repository key to publish to
             setUsername(System.getenv("BITESTS_PLATFORM_USERNAME")) // The publisher user name

--- a/src/functionalTest/resources/gradle-plugin/build.gradle
+++ b/src/functionalTest/resources/gradle-plugin/build.gradle
@@ -37,6 +37,7 @@ artifactory {
         }
         defaults {
             publications("ALL_PUBLICATIONS")
+            moduleType('GENERIC')
         }
     }
 }

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
@@ -19,6 +19,7 @@ import org.gradle.api.publish.maven.tasks.GenerateMavenPom;
 import org.gradle.api.publish.tasks.GenerateModuleMetadata;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.*;
+import org.jfrog.build.api.builder.ModuleType;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactSpecs;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 import org.jfrog.gradle.plugin.artifactory.Constant;
@@ -58,6 +59,8 @@ public class ArtifactoryTask extends DefaultTask {
     private final Map<String, Boolean> flags = new HashMap<>();
     // Is this task initiated from a build server
     private boolean ciServerBuild = false;
+    // Set the module type to a custom type, or "GRADLE" if not specified
+    private String moduleType = ModuleType.GRADLE.toString();
 
     @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Input field should be public")
     @Input
@@ -176,6 +179,16 @@ public class ArtifactoryTask extends DefaultTask {
             this.publications.addAll(Arrays.asList(publications));
             checkDependsOnArtifactsToPublish();
         }
+    }
+
+    /**
+     * Set a custom module type in the published build-info
+     *
+     * @param moduleType - Module type
+     */
+    @SuppressWarnings("unused")
+    public void moduleType(String moduleType) {
+        this.moduleType = moduleType;
     }
 
     /**
@@ -367,6 +380,12 @@ public class ArtifactoryTask extends DefaultTask {
     }
 
     @Input
+    @Optional
+    public String getModuleType() {
+        return moduleType;
+    }
+
+    @Input
     public Set<Publication> getPublications() {
         Set<Publication> publications = new HashSet<>();
         publications.addAll(ivyPublications);
@@ -430,6 +449,11 @@ public class ArtifactoryTask extends DefaultTask {
     @SuppressWarnings("unused")
     public void setCiServerBuild() {
         this.ciServerBuild = true;
+    }
+
+    @SuppressWarnings("unused")
+    public void setModuleType(String moduleType) {
+        this.moduleType = moduleType;
     }
 
     @SuppressWarnings("unused")

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/PluginUtils.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/PluginUtils.java
@@ -1,9 +1,13 @@
 package org.jfrog.gradle.plugin.artifactory.utils;
 
+import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.GradleException;
 import org.gradle.api.invocation.Gradle;
+import org.jfrog.build.api.builder.ModuleType;
 import org.jfrog.build.client.Version;
 import org.jfrog.gradle.plugin.artifactory.Constant;
+
+import java.util.Arrays;
 
 public class PluginUtils {
 
@@ -17,6 +21,23 @@ public class PluginUtils {
         String gradleVersion = gradle.getGradleVersion();
         if (!new Version(gradleVersion).isAtLeast(Constant.MIN_GRADLE_VERSION)) {
             throw new GradleException("Can't apply Artifactory Plugin on Gradle version " + gradleVersion + ". Minimum supported Gradle version is " + Constant.MIN_GRADLE_VERSION);
+        }
+    }
+
+    /**
+     * Get the {@link ModuleType} object from the user input or GRADLE.
+     *
+     * @param moduleType - Module type input from the user
+     * @return the ModuleType to set.
+     */
+    public static ModuleType getModuleType(String moduleType) {
+        if (StringUtils.isBlank(moduleType)) {
+            return ModuleType.GRADLE;
+        }
+        try {
+            return ModuleType.valueOf(StringUtils.upperCase(moduleType));
+        } catch (IllegalArgumentException illegalArgumentException) {
+            throw new GradleException("moduleType can only be one of " + Arrays.toString(ModuleType.values()), illegalArgumentException);
         }
     }
 }

--- a/src/test/java/org/jfrog/gradle/plugin/artifactory/utils/PluginUtilsTest.java
+++ b/src/test/java/org/jfrog/gradle/plugin/artifactory/utils/PluginUtilsTest.java
@@ -2,11 +2,15 @@ package org.jfrog.gradle.plugin.artifactory.utils;
 
 import org.gradle.api.GradleException;
 import org.gradle.api.invocation.Gradle;
+import org.jfrog.build.api.builder.ModuleType;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.jfrog.gradle.plugin.artifactory.utils.PluginUtils.assertGradleVersionSupported;
+import static org.jfrog.gradle.plugin.artifactory.utils.PluginUtils.getModuleType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 public class PluginUtilsTest {
@@ -31,4 +35,24 @@ public class PluginUtilsTest {
         when(gradle.getGradleVersion()).thenReturn("7.0");
         assertGradleVersionSupported(gradle);
     }
+
+    @DataProvider
+    public Object[][] moduleTypeCases() {
+        return new Object[][]{
+                {"", ModuleType.GRADLE, false},
+                {"cpp", ModuleType.CPP, false},
+                {"CPP", ModuleType.CPP, false},
+                {"NotExistedType", ModuleType.GENERIC, true}
+        };
+    }
+
+    @Test(dataProvider = "moduleTypeCases")
+    public void testGetModuleType(String actualModuleType, ModuleType expectedModuleType, boolean expectedException) {
+        if (expectedException) {
+            assertThrows(GradleException.class, () -> getModuleType(actualModuleType));
+        } else {
+            assertEquals(getModuleType(actualModuleType), expectedModuleType);
+        }
+    }
+
 }


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

Allow setting the module type manually:

```kotlin
configure<ArtifactoryPluginConvention> {
   publish {
       defaults {
           moduleType("CPP")
       }
   }
}
```

And within the project scope:

```kotlin
tasks.named<ArtifactoryTask>("artifactoryPublish") {
   setModuleType("CPP")
}
```
