### PR TITLE
Allow providing release and snapshot repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,12 @@ configure<ArtifactoryPluginConvention> {
         contextUrl = "http://127.0.0.1:8081/artifactory"
         // Define the project repository to which the artifacts will be published
         repository {
-            // Set the Artifactory repository key
+            // Option 1 - Define the Artifactory repository key
             repoKey = "libs-snapshot-local"
+            // Option 2 - Specify release and snapshot repositories; let the plugin decide to which one to publish
+            // releaseRepoKey = "libs-release-local"
+            // snapshotRepoKey = "libs-snapshot-local"
+
             // Specify the publisher username
             username = project.property("artifactory_user") as String
             // Provide the publisher password
@@ -268,8 +272,12 @@ artifactory {
         contextUrl = 'http://127.0.0.1:8081/artifactory'
         // Define the project repository to which the artifacts will be published
         repository {
-            // The Artifactory repository key
+            // Option 1 - Define the Artifactory repository key
             repoKey = 'libs-snapshot-local'
+            // Option 2 - Specify release and snapshot repositories; let the plugin decide to which one to publish
+            // releaseRepoKey = 'libs-release-local'
+            // snapshotRepoKey = 'libs-snapshot-local'
+            
             // The publisher username
             username = "${artifactory_user}"
             // The publisher password

--- a/src/functionalTest/resources/gradle-example-publish/build.gradle
+++ b/src/functionalTest/resources/gradle-example-publish/build.gradle
@@ -55,7 +55,8 @@ artifactory {
     publish {
         contextUrl = "$System.env.BITESTS_PLATFORM_URL"+"/artifactory"
         repository {
-            repoKey = "$System.env.BITESTS_ARTIFACTORY_LOCAL_REPO" // The Artifactory repository key to publish to
+            releaseRepoKey = "SHOULD_NOT_PUBLISH_RELEASES"
+            snapshotRepoKey = "$System.env.BITESTS_ARTIFACTORY_LOCAL_REPO" // The Artifactory repository key to publish to
             username = "$System.env.BITESTS_PLATFORM_USERNAME" // The publisher user name
             password = "$System.env.BITESTS_PLATFORM_ADMIN_TOKEN" // The publisher password
             // This is an optional section for configuring Ivy publication (when publishIvy = true).

--- a/src/functionalTest/resources/gradle-kts-example-publish/build.gradle.kts
+++ b/src/functionalTest/resources/gradle-kts-example-publish/build.gradle.kts
@@ -69,7 +69,8 @@ configure<ArtifactoryPluginConvention> {
     publish {
         setContextUrl(System.getenv("BITESTS_PLATFORM_URL")+"/artifactory")
         repository {
-            setRepoKey(System.getenv("BITESTS_ARTIFACTORY_LOCAL_REPO")) // The Artifactory repository key to publish to
+            setReleaseRepoKey("SHOULD_NOT_PUBLISH_RELEASES")
+            setSnapshotRepoKey(System.getenv("BITESTS_ARTIFACTORY_LOCAL_REPO")) // The Artifactory repository key to publish to
             setUsername(System.getenv("BITESTS_PLATFORM_USERNAME")) // The publisher user name
             setPassword(System.getenv("BITESTS_PLATFORM_ADMIN_TOKEN")) // The publisher password
             // This is an optional section for configuring Ivy publication (when publishIvy = true).

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/dsl/PublisherConfig.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/dsl/PublisherConfig.java
@@ -35,6 +35,7 @@ public class PublisherConfig {
         this.publisher.setContextUrl(contextUrl);
     }
 
+    @SuppressWarnings("unused")
     public void defaults(Action<ArtifactoryTask> defaultsAction) {
         this.defaultsAction = defaultsAction;
     }
@@ -91,6 +92,26 @@ public class PublisherConfig {
         @SuppressWarnings("unused")
         public void setRepoKey(String repoKey) {
             this.publisher.setRepoKey(repoKey);
+        }
+
+        @SuppressWarnings("unused")
+        public String getReleaseRepoKey() {
+            return publisher.getReleaseRepoKey();
+        }
+
+        @SuppressWarnings("unused")
+        public void setReleaseRepoKey(String releaseRepoKey) {
+            this.publisher.setReleaseRepoKey(releaseRepoKey);
+        }
+
+        @SuppressWarnings("unused")
+        public String getSnapshotRepoKey() {
+            return publisher.getSnapshotRepoKey();
+        }
+
+        @SuppressWarnings("unused")
+        public void setSnapshotRepoKey(String snapshotRepoKey) {
+            this.publisher.setSnapshotRepoKey(snapshotRepoKey);
         }
 
         public String getUsername() {


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

Resolves https://github.com/jfrog/artifactory-gradle-plugin/issues/47
Resolves https://github.com/jfrog/artifactory-gradle-plugin/issues/97

Option 1:
Let the plugin decide which to repository to publish the artifacts to by allowing the provision of both snapshot and release repositories.

```kotlin
configure<ArtifactoryPluginConvention> {
    publish {
        repoKey = "libs-snapshot-local"
    }
}
```
```groovy
artifactory {
    publish {
        repository {
            repoKey = "libs-snapshot-local"
        }
    }
}
```

Option 2 (new):
```kotlin
configure<ArtifactoryPluginConvention> {
    publish {
            releaseRepoKey = "libs-release-local"
            snapshotRepoKey = "libs-snapshot-local"
    }
}
```
```groovy
artifactory {
    publish {
        repository {
             releaseRepoKey = 'libs-release-local'
             snapshotRepoKey = 'libs-snapshot-local'
        }
    }
}
```