### PR TITLE
Handle signature files

### DIFF
--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/publication/IvyPublicationExtractor.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/publication/IvyPublicationExtractor.java
@@ -18,7 +18,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import static org.jfrog.gradle.plugin.artifactory.utils.PublicationUtils.addArtifactInfoToDeployDetails;
-import static org.jfrog.gradle.plugin.artifactory.utils.PublicationUtils.createArtifactBuilder;
 
 public class IvyPublicationExtractor extends PublicationExtractor<IvyPublication> {
 
@@ -95,10 +94,7 @@ public class IvyPublicationExtractor extends PublicationExtractor<IvyPublication
         if (!ivyFile.exists()) {
             return null;
         }
-        DeployDetails.Builder builder = createArtifactBuilder(ivyFile, publication.getName());
-        PublishArtifactInfo artifactInfo = new PublishArtifactInfo(
-                publication.getModule(), "xml", "ivy", null, extraInfo, ivyFile);
-        addArtifactToDeployDetails(publication, builder, artifactInfo);
+        buildAndPublishArtifactWithSignatures(ivyFile, publication, publication.getModule(), "xml", "ivy", null, extraInfo);
         return ivyFile;
     }
 
@@ -132,11 +128,7 @@ public class IvyPublicationExtractor extends PublicationExtractor<IvyPublication
             if (file.equals(ivyFile)) {
                 continue;
             }
-            DeployDetails.Builder builder = createArtifactBuilder(file, publication.getName());
-            PublishArtifactInfo artifactInfo = new PublishArtifactInfo(
-                    artifact.getName(), artifact.getExtension(), artifact.getType(), artifact.getClassifier(),
-                    extraInfo, file);
-            addArtifactToDeployDetails(publication, builder, artifactInfo);
+            buildAndPublishArtifactWithSignatures(file, publication, artifact.getName(), artifact.getExtension(), artifact.getType(), artifact.getClassifier(), extraInfo);
         }
     }
 }

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/publication/MavenPublicationExtractor.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/publication/MavenPublicationExtractor.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.jfrog.gradle.plugin.artifactory.utils.PublicationUtils.addArtifactInfoToDeployDetails;
-import static org.jfrog.gradle.plugin.artifactory.utils.PublicationUtils.createArtifactBuilder;
 
 public class MavenPublicationExtractor extends PublicationExtractor<MavenPublication> {
 
@@ -76,10 +75,7 @@ public class MavenPublicationExtractor extends PublicationExtractor<MavenPublica
         if (!pomFile.exists()) {
             return;
         }
-        DeployDetails.Builder builder = createArtifactBuilder(pomFile, publication.getName());
-        PublishArtifactInfo artifactInfo = new PublishArtifactInfo(
-                publication.getArtifactId(), "pom", "pom", null, pomFile);
-        addArtifactToDeployDetails(publication, builder, artifactInfo);
+        buildAndPublishArtifactWithSignatures(pomFile, publication, publication.getArtifactId(), "pom", "pom", null, null);
     }
 
     /**
@@ -112,11 +108,6 @@ public class MavenPublicationExtractor extends PublicationExtractor<MavenPublica
 
     private void createPublishArtifactInfoAndAddToDeployDetails(MavenArtifact artifact, MavenPublication publication) {
         File file = artifact.getFile();
-        DeployDetails.Builder builder = createArtifactBuilder(file, publication.getName());
-        PublishArtifactInfo artifactInfo = new PublishArtifactInfo(
-                publication.getArtifactId(), artifact.getExtension(),
-                artifact.getExtension(), artifact.getClassifier(),
-                file);
-        addArtifactToDeployDetails(publication, builder, artifactInfo);
+        buildAndPublishArtifactWithSignatures(file, publication, publication.getArtifactId(), artifact.getExtension(), artifact.getExtension(), artifact.getClassifier(), null);
     }
 }

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/publication/PublicationExtractor.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/publication/PublicationExtractor.java
@@ -2,16 +2,20 @@ package org.jfrog.gradle.plugin.artifactory.extractor.publication;
 
 import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.tasks.GenerateModuleMetadata;
+import org.gradle.plugins.signing.Sign;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
 import org.jfrog.gradle.plugin.artifactory.extractor.PublishArtifactInfo;
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask;
 
+import javax.xml.namespace.QName;
 import java.io.File;
+import java.util.Map;
 
 import static org.jfrog.gradle.plugin.artifactory.utils.PublicationUtils.createArtifactBuilder;
 
 public abstract class PublicationExtractor<ActualPublication extends Publication> {
     protected ArtifactoryTask artifactoryTask;
+    private final String[] signatureExtensions = {"asc", "sig"};
 
     public PublicationExtractor(ArtifactoryTask artifactoryTask) {
         this.artifactoryTask = artifactoryTask;
@@ -65,12 +69,37 @@ public abstract class PublicationExtractor<ActualPublication extends Publication
                 continue;
             }
 
-            DeployDetails.Builder builder = createArtifactBuilder(moduleMetadata, generateModuleMetadata.getPublication().get().getName());
-
             //noinspection unchecked
             ActualPublication actualPublication = (ActualPublication) publication;
-            PublishArtifactInfo artifactInfo = new PublishArtifactInfo(getPublicationArtifactId(actualPublication), "module", "module", null, moduleMetadata);
-            addArtifactToDeployDetails(actualPublication, builder, artifactInfo);
+            buildAndPublishArtifactWithSignatures(moduleMetadata, actualPublication, getPublicationArtifactId(actualPublication), "module", "module", null, null);
         }
+    }
+
+    protected void buildAndPublishArtifactWithSignatures(File file, ActualPublication publication, String artifactId, String artifactExtension, String artifactType, String artifactClassifier, Map<QName, String> extraInfo) {
+        buildAndPublishArtifact(file, publication, artifactId, artifactExtension, artifactType, artifactClassifier, extraInfo);
+        if (!isSignTaskExists()) {
+            return;
+        }
+        for (String signatureExtension : signatureExtensions) {
+            File signatureFile = new File(file.getAbsolutePath() + "." + signatureExtension);
+            if (!signatureFile.exists()) {
+                continue;
+            }
+            buildAndPublishArtifact(signatureFile, publication, artifactId, artifactType+"."+signatureExtension, artifactType+"."+signatureExtension, artifactClassifier, extraInfo);
+        }
+    }
+
+    private void buildAndPublishArtifact(File file, ActualPublication publication, String artifactId, String artifactExtension, String artifactType, String artifactClassifier, Map<QName, String> extraInfo) {
+        DeployDetails.Builder builder = createArtifactBuilder(file, publication.getName());
+        PublishArtifactInfo artifactInfo = new PublishArtifactInfo(
+                artifactId, artifactExtension, artifactType, artifactClassifier, extraInfo, file);
+        addArtifactToDeployDetails(publication, builder, artifactInfo);
+    }
+
+    private boolean isSignTaskExists() {
+        Sign signTask = artifactoryTask.getProject().getTasks().withType(Sign.class).stream()
+                .findAny()
+                .orElse(null);
+        return signTask != null;
     }
 }

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/publication/PublicationExtractor.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/publication/PublicationExtractor.java
@@ -15,6 +15,7 @@ import static org.jfrog.gradle.plugin.artifactory.utils.PublicationUtils.createA
 
 public abstract class PublicationExtractor<ActualPublication extends Publication> {
     protected ArtifactoryTask artifactoryTask;
+    // Signature types supported by the Signing plugin.
     private final String[] signatureExtensions = {"asc", "sig"};
 
     public PublicationExtractor(ArtifactoryTask artifactoryTask) {
@@ -75,6 +76,18 @@ public abstract class PublicationExtractor<ActualPublication extends Publication
         }
     }
 
+    /**
+     * Build and publish the artifact and add it to deploy details.
+     * If the Signing plugin was used, do the same to the artifact's signatures.
+     *
+     * @param file         - The file to publish
+     * @param publication  - The publication to extract details from
+     * @param artifactId   - The artifact ID
+     * @param artifactExtension - The artifact extension
+     * @param artifactType - The artifact type
+     * @param artifactClassifier - The artifact classifier
+     * @param extraInfo    - Extra information to add to the deploy details
+     */
     protected void buildAndPublishArtifactWithSignatures(File file, ActualPublication publication, String artifactId, String artifactExtension, String artifactType, String artifactClassifier, Map<QName, String> extraInfo) {
         buildAndPublishArtifact(file, publication, artifactId, artifactExtension, artifactType, artifactClassifier, extraInfo);
         if (!isSignTaskExists()) {
@@ -89,6 +102,17 @@ public abstract class PublicationExtractor<ActualPublication extends Publication
         }
     }
 
+    /**
+     * Build and publish the artifact and add it to deploy details.
+     *
+     * @param file         - The file to publish
+     * @param publication  - The publication to extract details from
+     * @param artifactId   - The artifact ID
+     * @param artifactExtension - The artifact extension
+     * @param artifactType - The artifact type
+     * @param artifactClassifier - The artifact classifier
+     * @param extraInfo    - Extra information to add to the deploy details
+     */
     private void buildAndPublishArtifact(File file, ActualPublication publication, String artifactId, String artifactExtension, String artifactType, String artifactClassifier, Map<QName, String> extraInfo) {
         DeployDetails.Builder builder = createArtifactBuilder(file, publication.getName());
         PublishArtifactInfo artifactInfo = new PublishArtifactInfo(
@@ -96,6 +120,9 @@ public abstract class PublicationExtractor<ActualPublication extends Publication
         addArtifactToDeployDetails(publication, builder, artifactInfo);
     }
 
+    /**
+     * @return true if the Signing plugin was used in the project
+     */
     private boolean isSignTaskExists() {
         Sign signTask = artifactoryTask.getProject().getTasks().withType(Sign.class).stream()
                 .findAny()

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/publication/PublicationExtractor.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/extractor/publication/PublicationExtractor.java
@@ -16,7 +16,7 @@ import static org.jfrog.gradle.plugin.artifactory.utils.PublicationUtils.createA
 public abstract class PublicationExtractor<ActualPublication extends Publication> {
     protected ArtifactoryTask artifactoryTask;
     // Signature types supported by the Signing plugin.
-    private final String[] signatureExtensions = {"asc", "sig"};
+    private final String[] SIGNATURE_EXTENSIONS = {"asc", "sig"};
 
     public PublicationExtractor(ArtifactoryTask artifactoryTask) {
         this.artifactoryTask = artifactoryTask;
@@ -80,38 +80,38 @@ public abstract class PublicationExtractor<ActualPublication extends Publication
      * Build and publish the artifact and add it to deploy details.
      * If the Signing plugin was used, do the same to the artifact's signatures.
      *
-     * @param file         - The file to publish
-     * @param publication  - The publication to extract details from
-     * @param artifactId   - The artifact ID
-     * @param artifactExtension - The artifact extension
-     * @param artifactType - The artifact type
+     * @param file               - The file to publish
+     * @param publication        - The publication to extract details from
+     * @param artifactId         - The artifact ID
+     * @param artifactExtension  - The artifact extension
+     * @param artifactType       - The artifact type
      * @param artifactClassifier - The artifact classifier
-     * @param extraInfo    - Extra information to add to the deploy details
+     * @param extraInfo          - Extra information to add to the deploy details
      */
     protected void buildAndPublishArtifactWithSignatures(File file, ActualPublication publication, String artifactId, String artifactExtension, String artifactType, String artifactClassifier, Map<QName, String> extraInfo) {
         buildAndPublishArtifact(file, publication, artifactId, artifactExtension, artifactType, artifactClassifier, extraInfo);
         if (!isSignTaskExists()) {
             return;
         }
-        for (String signatureExtension : signatureExtensions) {
+        for (String signatureExtension : SIGNATURE_EXTENSIONS) {
             File signatureFile = new File(file.getAbsolutePath() + "." + signatureExtension);
             if (!signatureFile.exists()) {
                 continue;
             }
-            buildAndPublishArtifact(signatureFile, publication, artifactId, artifactType+"."+signatureExtension, artifactType+"."+signatureExtension, artifactClassifier, extraInfo);
+            buildAndPublishArtifact(signatureFile, publication, artifactId, artifactType + "." + signatureExtension, artifactType + "." + signatureExtension, artifactClassifier, extraInfo);
         }
     }
 
     /**
      * Build and publish the artifact and add it to deploy details.
      *
-     * @param file         - The file to publish
-     * @param publication  - The publication to extract details from
-     * @param artifactId   - The artifact ID
-     * @param artifactExtension - The artifact extension
-     * @param artifactType - The artifact type
+     * @param file               - The file to publish
+     * @param publication        - The publication to extract details from
+     * @param artifactId         - The artifact ID
+     * @param artifactExtension  - The artifact extension
+     * @param artifactType       - The artifact type
      * @param artifactClassifier - The artifact classifier
-     * @param extraInfo    - Extra information to add to the deploy details
+     * @param extraInfo          - Extra information to add to the deploy details
      */
     private void buildAndPublishArtifact(File file, ActualPublication publication, String artifactId, String artifactExtension, String artifactType, String artifactClassifier, Map<QName, String> extraInfo) {
         DeployDetails.Builder builder = createArtifactBuilder(file, publication.getName());
@@ -124,9 +124,6 @@ public abstract class PublicationExtractor<ActualPublication extends Publication
      * @return true if the Signing plugin was used in the project
      */
     private boolean isSignTaskExists() {
-        Sign signTask = artifactoryTask.getProject().getTasks().withType(Sign.class).stream()
-                .findAny()
-                .orElse(null);
-        return signTask != null;
+        return !artifactoryTask.getProject().getTasks().withType(Sign.class).isEmpty();
     }
 }

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
@@ -196,7 +196,7 @@ public class ArtifactoryTask extends DefaultTask {
      * Extract the publications arguments for the task and make sure this task dependsOn the specified publications tasks.
      */
     private void checkDependsOnArtifactsToPublish() {
-        dependsOn(getProject().getTasks().withType(Sign.class));
+        createDependencyOnSigningTask();
         extractPublications();
         if (!hasPublications()) {
             if (publishPublicationsSpecified) {
@@ -211,6 +211,10 @@ public class ArtifactoryTask extends DefaultTask {
         createDependencyOnIvyPublications();
         createDependencyOnMavenPublications();
         createDependencyOnModuleMetadata();
+    }
+
+    private void createDependencyOnSigningTask() {
+        dependsOn(getProject().getTasks().withType(Sign.class));
     }
 
     /**

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
@@ -17,6 +17,7 @@ import org.gradle.api.publish.maven.tasks.GenerateMavenPom;
 import org.gradle.api.publish.tasks.GenerateModuleMetadata;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.*;
+import org.gradle.plugins.signing.Sign;
 import org.jfrog.build.api.builder.ModuleType;
 import org.jfrog.build.api.multiMap.Multimap;
 import org.jfrog.build.api.multiMap.SetMultimap;
@@ -195,6 +196,7 @@ public class ArtifactoryTask extends DefaultTask {
      * Extract the publications arguments for the task and make sure this task dependsOn the specified publications tasks.
      */
     private void checkDependsOnArtifactsToPublish() {
+        dependsOn(getProject().getTasks().withType(Sign.class));
         extractPublications();
         if (!hasPublications()) {
             if (publishPublicationsSpecified) {


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md) passed. If this feature is not already covered by the tests, I added new
  tests.

-----
Following #105 

Make the Artifactory Task depend on the Sign Task.
If the signing plugin was applied, add and deploy the signature files along with the files they signed.