### PR TITLE
Make the resolution repository preemptive

### DIFF
--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/PluginUtils.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/PluginUtils.java
@@ -69,7 +69,10 @@ public class PluginUtils {
                 credentials.setPassword(password);
             });
 
-            // Make the authentication preemptive
+            // Before resolving an artifact from Artifactory, Gradle typically sends a preemptive challenge request and
+            // expects a 401 response from the server.
+            // However, when 'Hide Existence of Unauthorized Resources' is enabled, Artifactory returns a 404 instead.
+            // Adding BasicAuthentication ensures that credentials are sent directly, bypassing this challenge.
             mavenArtifactRepository.authentication(authentications -> authentications.create("basic", BasicAuthentication.class));
         }
     }

--- a/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/PluginUtils.java
+++ b/src/main/java/org/jfrog/gradle/plugin/artifactory/utils/PluginUtils.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.invocation.Gradle;
+import org.gradle.authentication.http.BasicAuthentication;
 import org.jfrog.build.api.builder.ModuleType;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.client.Version;
@@ -67,6 +68,9 @@ public class PluginUtils {
                 credentials.setUsername(username);
                 credentials.setPassword(password);
             });
+
+            // Make the authentication preemptive
+            mavenArtifactRepository.authentication(authentications -> authentications.create("basic", BasicAuthentication.class));
         }
     }
 


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

Make the resolution repository preemptive to handle cases where the user has enabled `Hide Existence of Unauthorized Resources`. 

By default, Gradle sends an anonymous request during resolution and expects a 401 response from the server. However, when `Hide Existence of Unauthorized Resources` is active, Artifactory returns a 404 instead. This pull request addresses the issue by ensuring that Gradle sends credentials preemptively during resolution.

Refer to the Gradle documentation for more details on [preemptive authentication](https://docs.gradle.org/current/userguide/declaring_repositories_adv.html#sub:preemptive_authentication).