### PR TITLE
Fix security audit violations - upgrade build-info, jackson, commons-io

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,10 +15,10 @@ repositories {
     mavenCentral()
 }
 
-val buildInfoVersion = "2.41.22"
+val buildInfoVersion = "2.43.6"
 val fileSpecsVersion = "1.1.2"
 val commonsLangVersion = "3.18.0"
-val commonsIoVersion = "2.14.0"
+val commonsIoVersion = "2.18.0"
 val commonsTxtVersion = "1.10.0"
 val testNgVersion = "7.5.1"
 val httpclientVersion = "4.5.14"
@@ -43,7 +43,7 @@ dependencies {
     implementation("org.apache.ivy", "ivy", "2.5.2")
 
     // Dependencies that are used by the build-info dependencies and need to be included in the UberJar
-    implementation("com.fasterxml.jackson.core", "jackson-databind", "2.15.4")
+    implementation("com.fasterxml.jackson.core", "jackson-databind", "2.18.6")
     implementation("commons-io", "commons-io", commonsIoVersion)
     implementation("org.apache.httpcomponents", "httpclient", httpclientVersion)
 


### PR DESCRIPTION
- [ ] All [tests](../CONTRIBUTING.md) passed. If this feature is not already covered by the tests, I added new
  tests.

-----
**Title:** Fix security audit violations - upgrade build-info, jackson, commons-io

**Description:**
Upgrade vulnerable dependencies to resolve `jf audit` security violations.

- build-info-extractor: 2.41.22 → 2.43.6
- jackson-databind: 2.15.4 → 2.18.6
- commons-io: 2.14.0 → 2.18.0